### PR TITLE
fix(fleet): fix group tags editing - make it unable to delete tags

### DIFF
--- a/agent/policies/types.go
+++ b/agent/policies/types.go
@@ -50,7 +50,7 @@ var policyStateMap = [...]string{
 	"running",
 	"failed_to_apply",
 	"offline",
-	"NoTapMatch",
+	"no_tap_match",
 }
 
 var policyStateRevMap = map[string]PolicyState{

--- a/fleet/agent_group_service.go
+++ b/fleet/agent_group_service.go
@@ -300,7 +300,7 @@ func (svc fleetService) ValidateAgentGroup(ctx context.Context, token string, ag
 	}
 
 	ag.MFOwnerID = mfOwnerID
-	res, err := svc.agentRepo.RetrieveMatchingAgents(ctx, mfOwnerID, ag.Tags)
+	res, err := svc.agentRepo.RetrieveMatchingAgents(ctx, mfOwnerID, *ag.Tags)
 	if err != nil {
 		return AgentGroup{}, err
 	}

--- a/fleet/agent_group_service.go
+++ b/fleet/agent_group_service.go
@@ -131,6 +131,8 @@ func (svc fleetService) EditAgentGroup(ctx context.Context, token string, group 
 
 	if group.Tags == nil {
 		group.Tags = currentAgentGroup.Tags
+	} else if group.Tags != nil && len(*group.Tags) == 0 {
+		return AgentGroup{}, errors.Wrap(errors.ErrMalformedEntity, errors.New("group tags can not be empty"))
 	}
 
 	ag, err := svc.agentGroupRepository.Update(ctx, ownerID, group)

--- a/fleet/agent_group_service_test.go
+++ b/fleet/agent_group_service_test.go
@@ -56,6 +56,7 @@ var (
 	}
 	invalidName = strings.Repeat("m", maxNameSize+1)
 	metadata    = map[string]interface{}{"meta": "data"}
+	emptyTags   = types.Tags{}
 )
 
 func generateChannels() map[string]things.Channel {
@@ -125,13 +126,11 @@ func TestCreateAgentGroup(t *testing.T) {
 		MFOwnerID:   ownerID.String(),
 		Name:        nameID,
 		Description: &description,
-		Tags:        make(map[string]string),
-		Created:     time.Time{},
-	}
-
-	validAgent.Tags = map[string]string{
-		"region":    "eu",
-		"node_type": "dns",
+		Tags: &types.Tags{
+			"region":    "eu",
+			"node_type": "dns",
+		},
+		Created: time.Time{},
 	}
 
 	cases := map[string]struct {
@@ -403,21 +402,6 @@ func TestUpdateAgentGroup(t *testing.T) {
 			token: token,
 			err:   nil,
 		},
-		"update existing agent group with tags empty": {
-			group: fleet.AgentGroup{
-				ID:        ag.ID,
-				Name:      ag.Name,
-				MFOwnerID: ag.MFOwnerID,
-				Tags:      map[string]string{},
-			},
-			expectedGroup: fleet.AgentGroup{
-				Name:        ag.Name,
-				Tags:        map[string]string{},
-				Description: ag.Description,
-			},
-			token: token,
-			err:   nil,
-		},
 		"update existing agent group with tags omitted": {
 			group: fleet.AgentGroup{
 				ID:        ag.ID,
@@ -501,7 +485,7 @@ func createAgentGroup(t *testing.T, name string, svc fleet.AgentGroupService) (f
 	}
 	agCopy.Name = validName
 	agCopy.Description = &description
-	agCopy.Tags = map[string]string{
+	agCopy.Tags = &types.Tags{
 		"tag": "test",
 	}
 	ag, err := svc.CreateAgentGroup(context.Background(), token, agCopy)
@@ -545,12 +529,10 @@ func TestValidateAgentGroup(t *testing.T) {
 		MFOwnerID:   ownerID.String(),
 		Name:        nameID,
 		Description: &description,
-		Tags:        make(map[string]string),
-	}
-
-	validAgent.Tags = map[string]string{
-		"region":    "eu",
-		"node_type": "dns",
+		Tags: &types.Tags{
+			"region":    "eu",
+			"node_type": "dns",
+		},
 	}
 
 	cases := map[string]struct {

--- a/fleet/agent_group_service_test.go
+++ b/fleet/agent_group_service_test.go
@@ -416,6 +416,21 @@ func TestUpdateAgentGroup(t *testing.T) {
 			token: token,
 			err:   nil,
 		},
+		"update existing agent group with tags empty": {
+			group: fleet.AgentGroup{
+				ID:        ag.ID,
+				Name:      ag.Name,
+				MFOwnerID: ag.MFOwnerID,
+				Tags:      &emptyTags,
+			},
+			expectedGroup: fleet.AgentGroup{
+				Name:        ag.Name,
+				Tags:        ag.Tags,
+				Description: ag.Description,
+			},
+			token: token,
+			err:   errors.ErrMalformedEntity,
+		},
 	}
 
 	for desc, tc := range cases {
@@ -424,6 +439,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 			if err == nil {
 				assert.Equal(t, *tc.expectedGroup.Description, *agentGroupTest.Description, fmt.Sprintf("%s: expected %s got %s", desc, *tc.expectedGroup.Description, *agentGroupTest.Description))
 				assert.Equal(t, tc.expectedGroup.Name, agentGroupTest.Name, fmt.Sprintf("%s: expected %s got %s", desc, tc.expectedGroup.Name, agentGroupTest.Name))
+				assert.Equal(t, tc.expectedGroup.Tags, agentGroupTest.Tags, fmt.Sprintf("%s: expected %p got %p", desc, tc.expectedGroup.Tags, agentGroupTest.Tags))
 			}
 			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %d got %d", desc, tc.err, err))
 		})

--- a/fleet/agent_groups.go
+++ b/fleet/agent_groups.go
@@ -17,7 +17,7 @@ type AgentGroup struct {
 	Name           types.Identifier
 	Description    *string
 	MFChannelID    string
-	Tags           types.Tags
+	Tags           *types.Tags
 	Created        time.Time
 	MatchingAgents types.Metadata
 }

--- a/fleet/agent_service.go
+++ b/fleet/agent_service.go
@@ -194,6 +194,9 @@ func (svc fleetService) EditAgent(ctx context.Context, token string, agent Agent
 	if newName := agent.Name.String(); newName == "" {
 		agent.Name = currentAgent.Name
 	}
+	if agent.OrbTags == nil {
+		agent.OrbTags = currentAgent.OrbTags
+	}
 
 	err = svc.agentRepo.UpdateAgentByID(ctx, ownerID, agent)
 	if err != nil {

--- a/fleet/agent_service_test.go
+++ b/fleet/agent_service_test.go
@@ -251,10 +251,11 @@ func TestUpdateAgent(t *testing.T) {
 
 	validName, err := types.NewIdentifier("group")
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
-
 	_, _ = fleetService.CreateAgentGroup(context.Background(), "token", fleet.AgentGroup{
 		Name: validName,
-		Tags: map[string]string{"test": "true"},
+		Tags: &types.Tags{
+			"test": "true",
+		},
 	})
 
 	cases := map[string]struct {

--- a/fleet/agent_service_test.go
+++ b/fleet/agent_service_test.go
@@ -244,8 +244,8 @@ func TestUpdateAgent(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	ag, err := fleetService.CreateAgent(context.Background(), "token", fleet.Agent{
-		Name:      validAgentName,
-		AgentTags: map[string]string{"test": "true"},
+		Name:    validAgentName,
+		OrbTags: &types.Tags{"test": "true"},
 	})
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
@@ -257,6 +257,14 @@ func TestUpdateAgent(t *testing.T) {
 			"test": "true",
 		},
 	})
+
+	validAgentNameTestAttributeTags, err := types.NewIdentifier("tagsTest")
+	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
+	agentTestAttributeTags, err := fleetService.CreateAgent(context.Background(), "token", fleet.Agent{
+		Name:    validAgentNameTestAttributeTags,
+		OrbTags: &types.Tags{"test": "true"},
+	})
+	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
 	cases := map[string]struct {
 		agent         fleet.Agent
@@ -280,7 +288,7 @@ func TestUpdateAgent(t *testing.T) {
 			token: token,
 			err:   fleet.ErrNotFound,
 		},
-		"update existing agent without name": {
+		"update existing agent with omitted name": {
 			agent: fleet.Agent{
 				MFThingID: ag.MFThingID,
 				MFOwnerID: ag.MFOwnerID,
@@ -292,6 +300,31 @@ func TestUpdateAgent(t *testing.T) {
 			token: token,
 			err:   nil,
 		},
+		"update existing agent with empty tags": {
+			agent: fleet.Agent{
+				MFThingID: ag.MFThingID,
+				MFOwnerID: ag.MFOwnerID,
+				OrbTags:   &emptyTags,
+			},
+			expectedAgent: fleet.Agent{
+				Name:    ag.Name,
+				OrbTags: &emptyTags,
+			},
+			token: token,
+			err:   nil,
+		},
+		"update existing agent with omitted tags": {
+			agent: fleet.Agent{
+				MFThingID: agentTestAttributeTags.MFThingID,
+				MFOwnerID: agentTestAttributeTags.MFOwnerID,
+			},
+			expectedAgent: fleet.Agent{
+				Name:    agentTestAttributeTags.Name,
+				OrbTags: agentTestAttributeTags.OrbTags,
+			},
+			token: token,
+			err:   nil,
+		},
 	}
 
 	for desc, tc := range cases {
@@ -299,6 +332,7 @@ func TestUpdateAgent(t *testing.T) {
 			agentTest, err := fleetService.EditAgent(context.Background(), tc.token, tc.agent)
 			if err == nil {
 				assert.Equal(t, tc.expectedAgent.Name, agentTest.Name, fmt.Sprintf("%s: expected %s got %s", desc, tc.expectedAgent.Name, agentTest.Name))
+				assert.Equal(t, tc.expectedAgent.OrbTags, agentTest.OrbTags, fmt.Sprintf("%s: expected %p got %p", desc, tc.expectedAgent.OrbTags, agentTest.OrbTags))
 			}
 			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %d got %d", desc, tc.err, err))
 		})
@@ -315,12 +349,13 @@ func TestValidateAgent(t *testing.T) {
 	nameID, err := types.NewIdentifier("eu-agents")
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
+	emptyTags := types.Tags{}
 	validAgent := fleet.Agent{
 		MFOwnerID: ownerID.String(),
 		Name:      nameID,
-		OrbTags:   make(map[string]string),
+		OrbTags:   &emptyTags,
 	}
-	validAgent.OrbTags = map[string]string{
+	validAgent.OrbTags = &types.Tags{
 		"region":    "eu",
 		"node_type": "dns",
 	}
@@ -361,13 +396,14 @@ func TestCreateAgent(t *testing.T) {
 
 	conflictCase, err := createAgent(t, "agent", fleetService)
 
+	emptyTags := types.Tags{}
 	validAgent := fleet.Agent{
 		MFOwnerID: ownerID.String(),
 		Name:      nameID,
-		OrbTags:   make(map[string]string),
+		OrbTags:   &emptyTags,
 		Created:   time.Time{},
 	}
-	validAgent.OrbTags = map[string]string{
+	validAgent.OrbTags = &types.Tags{
 		"region":    "eu",
 		"node_type": "dns",
 	}
@@ -536,7 +572,7 @@ func TestViewAgentInfoByChannelIDInternal(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			agent, err := fleetService.ViewAgentInfoByChannelIDInternal(context.Background(), tc.channelID)
 			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s", desc, tc.err, err))
-			assert.Equal(t, tc.agent, agent, fmt.Sprintf("%s: expected %s got %s", desc, tc.agent, agent))
+			assert.Equal(t, tc.agent, agent, fmt.Sprintf("%s: expected %v got %v", desc, tc.agent, agent))
 		})
 	}
 }

--- a/fleet/agents.go
+++ b/fleet/agents.go
@@ -54,7 +54,7 @@ type Agent struct {
 	MFKeyID        string
 	MFChannelID    string
 	Created        time.Time
-	OrbTags        types.Tags
+	OrbTags        *types.Tags
 	AgentTags      types.Tags
 	AgentMetadata  types.Metadata
 	State          State

--- a/fleet/api/grpc/endpoint.go
+++ b/fleet/api/grpc/endpoint.go
@@ -83,7 +83,7 @@ func retrieveAgentInfoByChannelIDEndpoint(svc fleet.Service) endpoint.Endpoint {
 			ownerID:       agent.MFOwnerID,
 			agentName:     agent.Name.String(),
 			agentTags:     agent.AgentTags,
-			orbTags:       agent.OrbTags,
+			orbTags:       *agent.OrbTags,
 			agentGroupIDs: groupIDs,
 		}
 		return res, nil

--- a/fleet/api/http/endpoint.go
+++ b/fleet/api/http/endpoint.go
@@ -118,8 +118,8 @@ func editAgentGroupEndpoint(svc fleet.Service) endpoint.Endpoint {
 		}
 
 		var validName types.Identifier
-		if req.Name != "" {
-			validName, err = types.NewIdentifier(req.Name)
+		if req.Name != nil {
+			validName, err = types.NewIdentifier(*req.Name)
 			if err != nil {
 				return agentGroupRes{}, errors.Wrap(errors.ErrMalformedEntity, err)
 			}
@@ -183,7 +183,7 @@ func addAgentEndpoint(svc fleet.Service) endpoint.Endpoint {
 
 		agent := fleet.Agent{
 			Name:      nID,
-			OrbTags:   req.OrbTags,
+			OrbTags:   &req.OrbTags,
 			AgentTags: req.AgentTags,
 		}
 		saved, err := svc.CreateAgent(c, req.token, agent)
@@ -196,7 +196,7 @@ func addAgentEndpoint(svc fleet.Service) endpoint.Endpoint {
 			ID:            saved.MFThingID,
 			State:         saved.State.String(),
 			Key:           saved.MFKeyID,
-			OrbTags:       saved.OrbTags,
+			OrbTags:       *saved.OrbTags,
 			AgentTags:     saved.AgentTags,
 			AgentMetadata: saved.AgentMetadata,
 			LastHBData:    saved.LastHBData,
@@ -227,7 +227,7 @@ func viewAgentEndpoint(svc fleet.Service) endpoint.Endpoint {
 			Name:          ag.Name.String(),
 			ChannelID:     ag.MFChannelID,
 			AgentTags:     ag.AgentTags,
-			OrbTags:       ag.OrbTags,
+			OrbTags:       *ag.OrbTags,
 			TsCreated:     ag.Created,
 			AgentMetadata: ag.AgentMetadata,
 			State:         ag.State.String(),
@@ -308,7 +308,7 @@ func listAgentsEndpoint(svc fleet.Service) endpoint.Endpoint {
 				Name:        ag.Name.String(),
 				ChannelID:   ag.MFChannelID,
 				AgentTags:   ag.AgentTags,
-				OrbTags:     ag.OrbTags,
+				OrbTags:     *ag.OrbTags,
 				TsCreated:   ag.Created,
 				State:       ag.State.String(),
 				TsLastHB:    ag.LastHB,
@@ -361,16 +361,21 @@ func editAgentEndpoint(svc fleet.Service) endpoint.Endpoint {
 		}
 
 		var validName types.Identifier
-		if req.Name != "" {
-			validName, err = types.NewIdentifier(req.Name)
+		if req.Name != nil {
+			validName, err = types.NewIdentifier(*req.Name)
 			if err != nil {
 				return nil, errors.Wrap(errors.ErrMalformedEntity, err)
 			}
 		}
+		var agentOrbTags *types.Tags
+		if req.Tags != nil {
+			agentOrbTags = req.Tags
+		}
+
 		agent := fleet.Agent{
 			Name:      validName,
 			MFThingID: req.id,
-			OrbTags:   req.Tags,
+			OrbTags:   agentOrbTags,
 		}
 
 		ag, err := svc.EditAgent(ctx, req.token, agent)
@@ -383,7 +388,7 @@ func editAgentEndpoint(svc fleet.Service) endpoint.Endpoint {
 			Name:          ag.Name.String(),
 			ChannelID:     ag.MFChannelID,
 			AgentTags:     ag.AgentTags,
-			OrbTags:       ag.OrbTags,
+			OrbTags:       *ag.OrbTags,
 			TsCreated:     ag.Created,
 			AgentMetadata: ag.AgentMetadata,
 			State:         ag.State.String(),
@@ -410,7 +415,7 @@ func validateAgentEndpoint(svc fleet.Service) endpoint.Endpoint {
 
 		agent := fleet.Agent{
 			Name:    nID,
-			OrbTags: req.OrbTags,
+			OrbTags: &req.OrbTags,
 		}
 		validated, err := svc.ValidateAgent(c, req.token, agent)
 		if err != nil {
@@ -419,7 +424,7 @@ func validateAgentEndpoint(svc fleet.Service) endpoint.Endpoint {
 
 		res := validateAgentRes{
 			Name:    validated.Name.String(),
-			OrbTags: validated.OrbTags,
+			OrbTags: *validated.OrbTags,
 		}
 		return res, nil
 	}

--- a/fleet/api/http/endpoint.go
+++ b/fleet/api/http/endpoint.go
@@ -31,7 +31,7 @@ func addAgentGroupEndpoint(svc fleet.Service) endpoint.Endpoint {
 		group := fleet.AgentGroup{
 			Name:        nID,
 			Description: &req.Description,
-			Tags:        req.Tags,
+			Tags:        &req.Tags,
 		}
 		saved, err := svc.CreateAgentGroup(c, req.token, group)
 		if err != nil {
@@ -42,7 +42,7 @@ func addAgentGroupEndpoint(svc fleet.Service) endpoint.Endpoint {
 			ID:             saved.ID,
 			Name:           saved.Name.String(),
 			Description:    *saved.Description,
-			Tags:           saved.Tags,
+			Tags:           *saved.Tags,
 			MatchingAgents: saved.MatchingAgents,
 			created:        true,
 		}
@@ -65,7 +65,7 @@ func viewAgentGroupEndpoint(svc fleet.Service) endpoint.Endpoint {
 			ID:             agentGroup.ID,
 			Name:           agentGroup.Name.String(),
 			Description:    *agentGroup.Description,
-			Tags:           agentGroup.Tags,
+			Tags:           *agentGroup.Tags,
 			TsCreated:      agentGroup.Created,
 			MatchingAgents: agentGroup.MatchingAgents,
 		}
@@ -100,7 +100,7 @@ func listAgentGroupsEndpoint(svc fleet.Service) endpoint.Endpoint {
 				ID:             ag.ID,
 				Name:           ag.Name.String(),
 				Description:    *ag.Description,
-				Tags:           ag.Tags,
+				Tags:           *ag.Tags,
 				TsCreated:      ag.Created,
 				MatchingAgents: ag.MatchingAgents,
 			}
@@ -124,11 +124,16 @@ func editAgentGroupEndpoint(svc fleet.Service) endpoint.Endpoint {
 				return agentGroupRes{}, errors.Wrap(errors.ErrMalformedEntity, err)
 			}
 		}
+		var groupTags *types.Tags
+		if req.Tags != nil {
+			groupTags = req.Tags
+		}
+
 		ag := fleet.AgentGroup{
 			ID:          req.id,
 			Name:        validName,
 			Description: req.Description,
-			Tags:        req.Tags,
+			Tags:        groupTags,
 		}
 
 		data, err := svc.EditAgentGroup(ctx, req.token, ag)
@@ -140,7 +145,7 @@ func editAgentGroupEndpoint(svc fleet.Service) endpoint.Endpoint {
 			ID:             data.ID,
 			Name:           data.Name.String(),
 			Description:    *data.Description,
-			Tags:           data.Tags,
+			Tags:           *data.Tags,
 			TsCreated:      data.Created,
 			MatchingAgents: data.MatchingAgents,
 		}
@@ -330,7 +335,7 @@ func validateAgentGroupEndpoint(svc fleet.Service) endpoint.Endpoint {
 
 		group := fleet.AgentGroup{
 			Name: nID,
-			Tags: req.Tags,
+			Tags: &req.Tags,
 		}
 		validated, err := svc.ValidateAgentGroup(c, req.token, group)
 		if err != nil {
@@ -339,7 +344,7 @@ func validateAgentGroupEndpoint(svc fleet.Service) endpoint.Endpoint {
 
 		res := validateAgentGroupRes{
 			Name:           validated.Name.String(),
-			Tags:           validated.Tags,
+			Tags:           *validated.Tags,
 			MatchingAgents: validated.MatchingAgents,
 		}
 

--- a/fleet/api/http/endpoint_test.go
+++ b/fleet/api/http/endpoint_test.go
@@ -301,7 +301,7 @@ func TestListAgentGroup(t *testing.T) {
 			ID:             ag.ID,
 			Name:           ag.Name.String(),
 			Description:    *ag.Description,
-			Tags:           ag.Tags,
+			Tags:           *ag.Tags,
 			TsCreated:      ag.Created,
 			MatchingAgents: nil,
 		})
@@ -480,7 +480,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
 				Description: *ag.Description,
-				Tags:        ag.Tags,
+				Tags:        *ag.Tags,
 			}),
 			id:          ag.ID,
 			contentType: contentType,
@@ -498,7 +498,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
 				Description: *ag.Description,
-				Tags:        ag.Tags,
+				Tags:        *ag.Tags,
 			}),
 			id:          "invalid",
 			contentType: contentType,
@@ -509,7 +509,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
 				Description: *ag.Description,
-				Tags:        ag.Tags,
+				Tags:        *ag.Tags,
 			}),
 			id:          wrongID,
 			contentType: contentType,
@@ -520,7 +520,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
 				Description: *ag.Description,
-				Tags:        ag.Tags,
+				Tags:        *ag.Tags,
 			}),
 			id:          ag.ID,
 			contentType: contentType,
@@ -531,7 +531,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
 				Description: *ag.Description,
-				Tags:        ag.Tags,
+				Tags:        *ag.Tags,
 			}),
 			id:          ag.ID,
 			contentType: contentType,
@@ -542,7 +542,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
 				Description: *ag.Description,
-				Tags:        ag.Tags,
+				Tags:        *ag.Tags,
 			}),
 			id:          ag.ID,
 			contentType: "invalid",
@@ -553,7 +553,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 			req: toJSON(updateAgentGroupReq{
 				Name:        ag.Name.String(),
 				Description: *ag.Description,
-				Tags:        ag.Tags,
+				Tags:        *ag.Tags,
 			}),
 			id:          ag.ID,
 			contentType: "",
@@ -585,7 +585,7 @@ func TestUpdateAgentGroup(t *testing.T) {
 			req: toJSON(updateAgentGroupReq{
 				Name:        "g",
 				Description: *ag.Description,
-				Tags:        ag.Tags,
+				Tags:        *ag.Tags,
 			}),
 			id:          ag.ID,
 			contentType: contentType,
@@ -601,12 +601,12 @@ func TestUpdateAgentGroup(t *testing.T) {
 			id:          ag.ID,
 			contentType: contentType,
 			auth:        token,
-			status:      http.StatusOK,
+			status:      http.StatusBadRequest,
 		},
 		"update existing agent group with omitted name": {
 			req: toJSON(updateAgentGroupReq{
 				Description: *ag.Description,
-				Tags:        ag.Tags,
+				Tags:        *ag.Tags,
 			}),
 			id:          ag.ID,
 			contentType: contentType,
@@ -1633,7 +1633,7 @@ func createAgentGroup(t *testing.T, name string, cli *clientServer) (fleet.Agent
 	validName, err := types.NewIdentifier(name)
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 	agCopy.Name = validName
-	agCopy.Tags = tags
+	agCopy.Tags = &tags
 
 	description := "description example"
 	agCopy.Description = &description

--- a/fleet/api/http/requests.go
+++ b/fleet/api/http/requests.go
@@ -53,9 +53,9 @@ func (req addAgentGroupReq) validate() error {
 type updateAgentGroupReq struct {
 	id          string
 	token       string
-	Name        string     `json:"name,omitempty"`
-	Description *string    `json:"description,omitempty"`
-	Tags        types.Tags `json:"tags"`
+	Name        string      `json:"name,omitempty"`
+	Description *string     `json:"description,omitempty"`
+	Tags        *types.Tags `json:"tags"`
 }
 
 func (req updateAgentGroupReq) validate() error {
@@ -65,6 +65,11 @@ func (req updateAgentGroupReq) validate() error {
 	}
 	if req.Name == "" && req.Tags == nil && req.Description == nil {
 		return errors.ErrMalformedEntity
+	}
+	if req.Tags != nil {
+		if len(*req.Tags) == 0 {
+			return errors.ErrMalformedEntity
+		}
 	}
 
 	return nil

--- a/fleet/api/http/requests.go
+++ b/fleet/api/http/requests.go
@@ -53,7 +53,7 @@ func (req addAgentGroupReq) validate() error {
 type updateAgentGroupReq struct {
 	id          string
 	token       string
-	Name        string      `json:"name,omitempty"`
+	Name        *string     `json:"name,omitempty"`
 	Description *string     `json:"description,omitempty"`
 	Tags        *types.Tags `json:"tags"`
 }
@@ -63,13 +63,17 @@ func (req updateAgentGroupReq) validate() error {
 	if req.token == "" {
 		return errors.ErrUnauthorizedAccess
 	}
-	if req.Name == "" && req.Tags == nil && req.Description == nil {
+	if req.Name == nil && req.Tags == nil && req.Description == nil {
 		return errors.ErrMalformedEntity
 	}
 	if req.Tags != nil {
 		if len(*req.Tags) == 0 {
 			return errors.ErrMalformedEntity
 		}
+	}
+
+	if req.Name != nil && *req.Name == "" {
+		return errors.ErrMalformedEntity
 	}
 
 	return nil
@@ -102,8 +106,8 @@ func (req addAgentReq) validate() error {
 type updateAgentReq struct {
 	id    string
 	token string
-	Name  string     `json:"name,omitempty"`
-	Tags  types.Tags `json:"orb_tags,omitempty"`
+	Name  *string     `json:"name,omitempty"`
+	Tags  *types.Tags `json:"orb_tags,omitempty"`
 }
 
 func (req updateAgentReq) validate() error {
@@ -112,7 +116,11 @@ func (req updateAgentReq) validate() error {
 		return errors.ErrUnauthorizedAccess
 	}
 
-	if req.Name == "" && req.Tags == nil {
+	if req.Name == nil && req.Tags == nil {
+		return errors.ErrMalformedEntity
+	}
+
+	if req.Name != nil && *req.Name == "" {
 		return errors.ErrMalformedEntity
 	}
 

--- a/fleet/comms_test.go
+++ b/fleet/comms_test.go
@@ -226,7 +226,9 @@ func TestNotifyAgentAllDatasets(t *testing.T) {
 
 	group, err := fleetSVC.CreateAgentGroup(context.Background(), "token", fleet.AgentGroup{
 		Name: validGroupName,
-		Tags: map[string]string{"test": "true"},
+		Tags: &types.Tags{
+			"test": "true",
+		},
 	})
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
@@ -365,7 +367,9 @@ func TestNotifyAgentGroupMembership(t *testing.T) {
 
 	_, err = fleetSVC.CreateAgentGroup(context.Background(), "token", fleet.AgentGroup{
 		Name: validGroupName,
-		Tags: map[string]string{"test": "true"},
+		Tags: &types.Tags{
+			"test": "true",
+		},
 	})
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 
@@ -497,7 +501,9 @@ func TestNotifyAgentNewGroupMembership(t *testing.T) {
 
 	_, err = fleetSVC.CreateAgentGroup(context.Background(), "token", fleet.AgentGroup{
 		Name: validGroupName,
-		Tags: map[string]string{"test": "true"},
+		Tags: &types.Tags{
+			"test": "true",
+		},
 	})
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 

--- a/fleet/postgres/agent_groups.go
+++ b/fleet/postgres/agent_groups.go
@@ -392,17 +392,27 @@ func toDBAgentGroup(group fleet.AgentGroup) (dbAgentGroup, error) {
 		description = *group.Description
 	}
 
+	groupTags := make(db.Tags)
+	if group.Tags != nil {
+		groupTags = db.Tags(*group.Tags)
+	}
+
 	return dbAgentGroup{
 		ID:          group.ID,
 		Name:        group.Name,
 		Description: description,
 		MFOwnerID:   group.MFOwnerID,
 		MFChannelID: group.MFChannelID,
-		Tags:        db.Tags(group.Tags),
+		Tags:        groupTags,
 	}, nil
 
 }
 func toAgentGroup(dba dbAgentGroup) (fleet.AgentGroup, error) {
+
+	groupTags := make(types.Tags)
+	if len(dba.Tags) != 0 {
+		groupTags.Merge(dba.Tags)
+	}
 
 	return fleet.AgentGroup{
 		ID:             dba.ID,
@@ -411,7 +421,7 @@ func toAgentGroup(dba dbAgentGroup) (fleet.AgentGroup, error) {
 		MFOwnerID:      dba.MFOwnerID,
 		MFChannelID:    dba.MFChannelID,
 		Created:        dba.Created,
-		Tags:           types.Tags(dba.Tags),
+		Tags:           &groupTags,
 		MatchingAgents: types.Metadata(dba.MatchingAgents),
 	}, nil
 

--- a/fleet/postgres/agent_groups_test.go
+++ b/fleet/postgres/agent_groups_test.go
@@ -454,7 +454,7 @@ func TestAgentGroupRetrieveAllByAgent(t *testing.T) {
 		MFThingID:   thID.String(),
 		MFOwnerID:   oID.String(),
 		MFChannelID: chID.String(),
-		OrbTags:     types.Tags{"testkey": "testvalue"},
+		OrbTags:     &types.Tags{"testkey": "testvalue"},
 		AgentTags:   types.Tags{"testkey": "testvalue"},
 		LastHBData:  types.Metadata{"heartbeatdata": "testvalue"},
 	}
@@ -495,7 +495,7 @@ func TestAgentGroupRetrieveAllByAgent(t *testing.T) {
 				MFThingID:   wrongID.String(),
 				MFOwnerID:   oID.String(),
 				MFChannelID: chID.String(),
-				OrbTags:     types.Tags{"testkey": "testvalue"},
+				OrbTags:     &types.Tags{"testkey": "testvalue"},
 				AgentTags:   types.Tags{"testkey": "testvalue"},
 				LastHBData:  types.Metadata{"heartbeatdata": "testvalue"},
 			},
@@ -537,7 +537,7 @@ func TestRetrieveMatchingGroups(t *testing.T) {
 		MFThingID:   thID.String(),
 		MFOwnerID:   oID.String(),
 		MFChannelID: chID.String(),
-		OrbTags:     types.Tags{"testkey": "testvalue"},
+		OrbTags:     &types.Tags{"testkey": "testvalue"},
 		LastHBData:  types.Metadata{"heartbeatdata": "testvalue"},
 	}
 

--- a/fleet/postgres/agent_groups_test.go
+++ b/fleet/postgres/agent_groups_test.go
@@ -45,7 +45,7 @@ func TestAgentGroupSave(t *testing.T) {
 		Name:        nameID,
 		MFOwnerID:   oID.String(),
 		MFChannelID: chID.String(),
-		Tags:        types.Tags{"testkey": "testvalue"},
+		Tags:        &types.Tags{"testkey": "testvalue"},
 	}
 
 	groupCopy := group
@@ -102,7 +102,7 @@ func TestAgentGroupRetrieve(t *testing.T) {
 		Description: &description,
 		MFOwnerID:   oID.String(),
 		MFChannelID: chID.String(),
-		Tags:        types.Tags{"testkey": "testvalue"},
+		Tags:        &types.Tags{"testkey": "testvalue"},
 	}
 
 	id, err := agentGroupRepo.Save(context.Background(), group)
@@ -144,7 +144,7 @@ func TestAgentGroupRetrieve(t *testing.T) {
 				assert.Equal(t, nameID, ag.Name, fmt.Sprintf("%s: expected %s got %s\n", desc, nameID, ag.Name))
 			}
 			if len(tc.tags) > 0 {
-				assert.Equal(t, tc.tags, ag.Tags)
+				assert.Equal(t, tc.tags, *ag.Tags)
 			}
 			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
 		})
@@ -175,7 +175,7 @@ func TestMultiAgentGroupRetrieval(t *testing.T) {
 			Description: &description,
 			MFOwnerID:   oID.String(),
 			MFChannelID: chID.String(),
-			Tags:        types.Tags{"testkey": "testvalue"},
+			Tags:        &types.Tags{"testkey": "testvalue"},
 		}
 
 		ag, err := agentGroupRepo.Save(context.Background(), group)
@@ -297,7 +297,7 @@ func TestAgentGroupUpdate(t *testing.T) {
 		Name:        nameID,
 		MFOwnerID:   oID.String(),
 		MFChannelID: chID.String(),
-		Tags:        types.Tags{"testkey": "testvalue"},
+		Tags:        &types.Tags{"testkey": "testvalue"},
 	}
 
 	groupID, err := groupRepo.Save(context.Background(), group)
@@ -311,7 +311,7 @@ func TestAgentGroupUpdate(t *testing.T) {
 		Name:        nameConflict,
 		MFOwnerID:   oID.String(),
 		MFChannelID: chID.String(),
-		Tags:        types.Tags{"testkey": "testvalue"},
+		Tags:        &types.Tags{"testkey": "testvalue"},
 	}
 
 	_, err = groupRepo.Save(context.Background(), groupConflictName)
@@ -359,7 +359,7 @@ func TestAgentGroupUpdate(t *testing.T) {
 				Name:        nameConflict,
 				MFOwnerID:   oID.String(),
 				MFChannelID: chID.String(),
-				Tags:        types.Tags{"testkey": "testvalue"},
+				Tags:        &types.Tags{"testkey": "testvalue"},
 			},
 			err: errors.ErrConflict,
 		},
@@ -393,7 +393,7 @@ func TestAgentGroupDelete(t *testing.T) {
 		Name:        nameID,
 		MFOwnerID:   oID.String(),
 		MFChannelID: chID.String(),
-		Tags:        types.Tags{"testkey": "testvalue"},
+		Tags:        &types.Tags{"testkey": "testvalue"},
 	}
 
 	groupID, err := groupRepo.Save(context.Background(), group)
@@ -473,7 +473,7 @@ func TestAgentGroupRetrieveAllByAgent(t *testing.T) {
 			Description: &description,
 			MFOwnerID:   oID.String(),
 			MFChannelID: chID.String(),
-			Tags:        types.Tags{"testkey": "testvalue"},
+			Tags:        &types.Tags{"testkey": "testvalue"},
 		}
 
 		ag, err := agentGroupRepo.Save(context.Background(), group)
@@ -555,7 +555,7 @@ func TestRetrieveMatchingGroups(t *testing.T) {
 			Description: &description,
 			MFOwnerID:   oID.String(),
 			MFChannelID: chID.String(),
-			Tags:        types.Tags{"testkey": "testvalue"},
+			Tags:        &types.Tags{"testkey": "testvalue"},
 		}
 
 		ag, err := agentGroupRepo.Save(context.Background(), group)

--- a/fleet/postgres/agents.go
+++ b/fleet/postgres/agents.go
@@ -531,12 +531,17 @@ type dbMatchingAgent struct {
 
 func toDBAgent(agent fleet.Agent) (dbAgent, error) {
 
+	orbTags := types.Tags{}
+	if agent.OrbTags != nil {
+		orbTags = *agent.OrbTags
+	}
+
 	a := dbAgent{
 		Name:          agent.Name,
 		MFOwnerID:     agent.MFOwnerID,
 		MFThingID:     agent.MFThingID,
 		MFChannelID:   agent.MFChannelID,
-		OrbTags:       db.Tags(agent.OrbTags),
+		OrbTags:       db.Tags(orbTags),
 		AgentTags:     db.Tags(agent.AgentTags),
 		AgentMetadata: db.Metadata(agent.AgentMetadata),
 		State:         agent.State,
@@ -555,13 +560,15 @@ func toDBAgent(agent fleet.Agent) (dbAgent, error) {
 
 func toAgent(dba dbAgent) (fleet.Agent, error) {
 
+	orbTags := types.Tags(dba.OrbTags)
+
 	agent := fleet.Agent{
 		Name:          dba.Name,
 		MFOwnerID:     dba.MFOwnerID,
 		MFThingID:     dba.MFThingID,
 		MFChannelID:   dba.MFChannelID,
 		Created:       dba.Created,
-		OrbTags:       types.Tags(dba.OrbTags),
+		OrbTags:       &orbTags,
 		AgentTags:     types.Tags(dba.AgentTags),
 		AgentMetadata: types.Metadata(dba.AgentMetadata),
 		State:         dba.State,

--- a/fleet/postgres/agents_test.go
+++ b/fleet/postgres/agents_test.go
@@ -815,7 +815,7 @@ func TestMultiAgentRetrievalByAgentGroup(t *testing.T) {
 		Name:        groupNameID,
 		MFOwnerID:   oID.String(),
 		MFChannelID: chID.String(),
-		Tags:        tags,
+		Tags:        &tags,
 	}
 
 	id, err := agentGroupRepo.Save(context.Background(), group)

--- a/fleet/postgres/agents_test.go
+++ b/fleet/postgres/agents_test.go
@@ -61,7 +61,7 @@ func TestAgentSave(t *testing.T) {
 		MFThingID:     thID.String(),
 		MFOwnerID:     oID.String(),
 		MFChannelID:   chID.String(),
-		OrbTags:       types.Tags{"testkey": "testvalue"},
+		OrbTags:       &types.Tags{"testkey": "testvalue"},
 		AgentTags:     types.Tags{"testkey": "testvalue"},
 		AgentMetadata: types.Metadata{"testkey": "testvalue"},
 	}
@@ -154,7 +154,7 @@ func TestAgentRetrieve(t *testing.T) {
 		MFThingID:     thID.String(),
 		MFOwnerID:     oID.String(),
 		MFChannelID:   chID.String(),
-		OrbTags:       types.Tags{"testkey": "testvalue"},
+		OrbTags:       &types.Tags{"testkey": "testvalue"},
 		AgentTags:     types.Tags{"testkey": "testvalue"},
 		AgentMetadata: types.Metadata{"testkey": "testvalue"},
 	}
@@ -188,7 +188,7 @@ func TestAgentRetrieve(t *testing.T) {
 				assert.Equal(t, nameID, ag.Name, fmt.Sprintf("%s: expected %s got %s\n", desc, nameID, ag.Name))
 			}
 			if len(tc.tags) > 0 {
-				assert.Equal(t, tc.tags, ag.OrbTags)
+				assert.Equal(t, tc.tags, *ag.OrbTags)
 				assert.Equal(t, tc.tags, ag.AgentTags)
 			}
 			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
@@ -217,7 +217,7 @@ func TestAgentUpdateData(t *testing.T) {
 		MFThingID:     thID.String(),
 		MFOwnerID:     oID.String(),
 		MFChannelID:   chID.String(),
-		OrbTags:       types.Tags{"testkey": "testvalue"},
+		OrbTags:       &types.Tags{"testkey": "testvalue"},
 		AgentTags:     types.Tags{"testkey": "testvalue"},
 		AgentMetadata: types.Metadata{"testkey": "testvalue"},
 	}
@@ -409,7 +409,7 @@ func TestMultiAgentRetrieval(t *testing.T) {
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 		th.AgentMetadata = metadata
 		th.AgentTags = tags
-		th.OrbTags = subTags
+		th.OrbTags = &subTags
 
 		err = agentRepo.Save(context.Background(), th)
 		require.Nil(t, err, fmt.Sprintf("unexpected error: %s\n", err))
@@ -577,7 +577,7 @@ func TestAgentUpdate(t *testing.T) {
 		MFThingID:     thID.String(),
 		MFOwnerID:     oID.String(),
 		MFChannelID:   chID.String(),
-		OrbTags:       types.Tags{"testkey": "testvalue"},
+		OrbTags:       &types.Tags{"testkey": "testvalue"},
 		AgentTags:     types.Tags{"testkey": "testvalue"},
 		AgentMetadata: types.Metadata{"testkey": "testvalue"},
 	}
@@ -587,7 +587,7 @@ func TestAgentUpdate(t *testing.T) {
 		MFThingID:     duplicatedThID.String(),
 		MFOwnerID:     oID.String(),
 		MFChannelID:   chID.String(),
-		OrbTags:       types.Tags{"testkey": "testvalue"},
+		OrbTags:       &types.Tags{"testkey": "testvalue"},
 		AgentTags:     types.Tags{"testkey": "testvalue"},
 		AgentMetadata: types.Metadata{"testkey": "testvalue"},
 	}
@@ -607,7 +607,7 @@ func TestAgentUpdate(t *testing.T) {
 				MFThingID: thID.String(),
 				MFOwnerID: oID.String(),
 				Name:      updatedNameID,
-				OrbTags:   types.Tags{"newkey": "newvalue"},
+				OrbTags:   &types.Tags{"newkey": "newvalue"},
 			},
 			err: nil,
 		},
@@ -616,7 +616,7 @@ func TestAgentUpdate(t *testing.T) {
 				MFThingID: oID.String(),
 				MFOwnerID: oID.String(),
 				Name:      updatedNameID,
-				OrbTags:   types.Tags{"newkey": "newvalue"},
+				OrbTags:   &types.Tags{"newkey": "newvalue"},
 			},
 			err: errors.ErrNotFound,
 		},
@@ -625,7 +625,7 @@ func TestAgentUpdate(t *testing.T) {
 				MFThingID: "",
 				MFOwnerID: oID.String(),
 				Name:      updatedNameID,
-				OrbTags:   types.Tags{"newkey": "newvalue"},
+				OrbTags:   &types.Tags{"newkey": "newvalue"},
 			},
 			err: errors.ErrMalformedEntity,
 		},
@@ -634,7 +634,7 @@ func TestAgentUpdate(t *testing.T) {
 				MFThingID: thID.String(),
 				MFOwnerID: "",
 				Name:      updatedNameID,
-				OrbTags:   types.Tags{"newkey": "newvalue"},
+				OrbTags:   &types.Tags{"newkey": "newvalue"},
 			},
 			err: errors.ErrMalformedEntity,
 		},
@@ -694,7 +694,7 @@ func TestDeleteAgent(t *testing.T) {
 		MFThingID:     thID.String(),
 		MFOwnerID:     oID.String(),
 		MFChannelID:   chID.String(),
-		OrbTags:       types.Tags{"testkey": "testvalue"},
+		OrbTags:       &types.Tags{"testkey": "testvalue"},
 		AgentTags:     types.Tags{"testkey": "testvalue"},
 		AgentMetadata: types.Metadata{"testkey": "testvalue"},
 	}
@@ -749,7 +749,7 @@ func TestAgentBackendTapsRetrieve(t *testing.T) {
 		MFThingID:     thID.String(),
 		MFOwnerID:     oID.String(),
 		MFChannelID:   chID.String(),
-		OrbTags:       types.Tags{"testkey": "testvalue"},
+		OrbTags:       &types.Tags{"testkey": "testvalue"},
 		AgentTags:     types.Tags{"testkey": "testvalue"},
 		AgentMetadata: types.Metadata{"testkey": "testvalue"},
 	}
@@ -838,7 +838,7 @@ func TestMultiAgentRetrievalByAgentGroup(t *testing.T) {
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 		th.AgentMetadata = metadata
 		th.AgentTags = tags
-		th.OrbTags = subTags
+		th.OrbTags = &subTags
 		th.State = fleet.Online
 
 		err = agentRepo.Save(context.Background(), th)
@@ -914,7 +914,7 @@ func TestAgentRetrieveByID(t *testing.T) {
 		MFThingID:     thID.String(),
 		MFOwnerID:     oID.String(),
 		MFChannelID:   chID.String(),
-		OrbTags:       types.Tags{"testkey": "testvalue"},
+		OrbTags:       &types.Tags{"testkey": "testvalue"},
 		AgentTags:     types.Tags{"testkey": "testvalue"},
 		AgentMetadata: types.Metadata{"testkey": "testvalue"},
 	}
@@ -953,7 +953,7 @@ func TestAgentRetrieveByID(t *testing.T) {
 				assert.Equal(t, nameID, ag.Name, fmt.Sprintf("%s: expected %s got %s\n", desc, nameID, ag.Name))
 			}
 			if len(tc.tags) > 0 {
-				assert.Equal(t, tc.tags, ag.OrbTags)
+				assert.Equal(t, tc.tags, *ag.OrbTags)
 				assert.Equal(t, tc.tags, ag.AgentTags)
 			}
 			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
@@ -982,7 +982,7 @@ func TestRetrieveAgentInfoByChannelID(t *testing.T) {
 		MFThingID:     thID.String(),
 		MFOwnerID:     oID.String(),
 		MFChannelID:   chID.String(),
-		OrbTags:       types.Tags{"testkey": "testvalue"},
+		OrbTags:       &types.Tags{"testkey": "testvalue"},
 		AgentTags:     types.Tags{"testkey": "testvalue"},
 		AgentMetadata: types.Metadata{"testkey": "testvalue"},
 	}
@@ -1004,7 +1004,7 @@ func TestRetrieveAgentInfoByChannelID(t *testing.T) {
 			ownerID:   oID.String(),
 			name:      nameID.String(),
 			agentTags: agent.AgentTags,
-			orbTags:   agent.OrbTags,
+			orbTags:   *agent.OrbTags,
 			agentID:   agent.MFThingID,
 			err:       nil,
 		},
@@ -1026,7 +1026,7 @@ func TestRetrieveAgentInfoByChannelID(t *testing.T) {
 				assert.Equal(t, tc.name, ag.Name.String(), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.name, ag.Name.String()))
 				assert.Equal(t, tc.ownerID, ag.MFOwnerID, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.ownerID, ag.MFOwnerID))
 				assert.Equal(t, tc.agentTags, ag.AgentTags, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.agentTags, ag.AgentTags))
-				assert.Equal(t, tc.orbTags, ag.OrbTags, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.orbTags, ag.OrbTags))
+				assert.Equal(t, tc.orbTags, *ag.OrbTags, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.orbTags, *ag.OrbTags))
 				assert.Equal(t, tc.agentID, ag.MFThingID, fmt.Sprintf("%s: expected %s got %s\n", desc, tc.agentID, ag.MFThingID))
 			}
 			assert.True(t, errors.Contains(err, tc.err), fmt.Sprintf("%s: expected %s got %s\n", desc, tc.err, err))
@@ -1089,7 +1089,7 @@ func TestMatchingAgentRetrieval(t *testing.T) {
 		require.True(t, th.Name.IsValid(), "invalid Identifier name: %s")
 		require.Nil(t, err, fmt.Sprintf("got unexpected error: %s", err))
 		th.AgentTags = agentTags
-		th.OrbTags = orbTags
+		th.OrbTags = &orbTags
 
 		err = agentRepo.Save(context.Background(), th)
 		require.Nil(t, err, fmt.Sprintf("unexpected error: %s\n", err))
@@ -1178,7 +1178,7 @@ func TestSetAgentStale(t *testing.T) {
 		MFThingID:     thID.String(),
 		MFOwnerID:     oID.String(),
 		MFChannelID:   chID.String(),
-		OrbTags:       types.Tags{"testkey": "testvalue"},
+		OrbTags:       &types.Tags{"testkey": "testvalue"},
 		AgentTags:     types.Tags{"testkey": "testvalue"},
 		AgentMetadata: types.Metadata{"testkey": "testvalue"},
 		LastHB:        time.Now().Add(fleet.DefaultTimeout),

--- a/policies/postgres/policies.go
+++ b/policies/postgres/policies.go
@@ -832,10 +832,6 @@ func toDataset(dba dbDataset) policies.Dataset {
 		Tags:         types.Tags(dba.Tags),
 	}
 
-	//var sinkIDs []string
-	//sinkIDs = dba.SinkIDs
-	//dataset.SinkIDs = &sinkIDs
-
 	return dataset
 }
 

--- a/sinker/message_handler.go
+++ b/sinker/message_handler.go
@@ -30,7 +30,7 @@ func (svc SinkerService) remoteWriteToPrometheus(tsList prometheus.TSList, owner
 	}
 	if cfgRepo.Opentelemetry == "enabled" {
 		svc.logger.Info("ignoring sink state update on OpenTelemetry sinks")
-		return nil	
+		return nil
 	}
 	cfg := prometheus.NewConfig(
 		prometheus.WriteURLOption(cfgRepo.Url),
@@ -128,7 +128,7 @@ func (svc SinkerService) handleMetrics(ctx context.Context, agentID string, chan
 		MFOwnerID:   agentPb.OwnerID,
 		MFThingID:   agentID,
 		MFChannelID: channelID,
-		OrbTags:     agentPb.OrbTags,
+		OrbTags:     (*types.Tags)(&agentPb.OrbTags),
 		AgentTags:   agentPb.AgentTags,
 	}
 


### PR DESCRIPTION
Make it unable to delete group tags on the editing process, and fix unit tests