### PR TITLE
Removing logging extension on otel collector

### DIFF
--- a/maestro/config/config_builder.go
+++ b/maestro/config/config_builder.go
@@ -246,7 +246,7 @@ func ReturnConfigYamlFromSink(_ context.Context, kafkaUrlConfig, sinkId, sinkUrl
 					Exporters  []string `json:"exporters" yaml:"exporters"`
 				}{
 					Receivers: []string{"kafka"},
-					Exporters: []string{"prometheusremotewrite", "logging"},
+					Exporters: []string{"prometheusremotewrite"},
 				},
 			},
 		},

--- a/maestro/config/config_builder_test.go
+++ b/maestro/config/config_builder_test.go
@@ -27,7 +27,7 @@ func TestReturnConfigYamlFromSink(t *testing.T) {
 			sinkUrl:        "https://mysinkurl:9922",
 			sinkUsername:   "1234123",
 			sinkPassword:   "CarnivorousVulgaris",
-		}, want: `---\nreceivers:\n  kafka:\n    brokers:\n    - kafka:9092\n    topic: otlp_metrics-sink-id-222\n    protocol_version: 2.0.0\nextensions:\n  pprof:\n    endpoint: 0.0.0.0:1888\n  basicauth/exporter:\n    client_auth:\n      username: 1234123\n      password: CarnivorousVulgaris\nexporters:\n  prometheusremotewrite:\n    endpoint: https://mysinkurl:9922\n    auth:\n      authenticator: basicauth/exporter\n  logging:\n    verbosity: detailed\n    sampling_initial: 5\n    sampling_thereafter: 50\nservice:\n  extensions:\n  - pprof\n  - basicauth/exporter\n  pipelines:\n    metrics:\n      receivers:\n      - kafka\n      exporters:\n      - prometheusremotewrite\n      - logging\n`,
+		}, want: `---\nreceivers:\n  kafka:\n    brokers:\n    - kafka:9092\n    topic: otlp_metrics-sink-id-222\n    protocol_version: 2.0.0\nextensions:\n  pprof:\n    endpoint: 0.0.0.0:1888\n  basicauth/exporter:\n    client_auth:\n      username: 1234123\n      password: CarnivorousVulgaris\nexporters:\n  prometheusremotewrite:\n    endpoint: https://mysinkurl:9922\n    auth:\n      authenticator: basicauth/exporter\n  logging:\n    verbosity: detailed\n    sampling_initial: 5\n    sampling_thereafter: 50\nservice:\n  extensions:\n  - pprof\n  - basicauth/exporter\n  pipelines:\n    metrics:\n      receivers:\n      - kafka\n      exporters:\n      - prometheusremotewrite\n`,
 			wantErr: false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR deactivate loggin extension on otel collector to reduce unecessary verbose on logs