### PR TITLE
[FIX] on logic for active and error sinks status

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -11,13 +11,6 @@ package main
 import (
 	"context"
 	"fmt"
-	sinksgrpc "github.com/ns1labs/orb/sinks/api/grpc"
-	"github.com/opentracing/opentracing-go"
-	"github.com/spf13/viper"
-	jconfig "github.com/uber/jaeger-client-go/config"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"io"
 	"os"
 	"os/signal"
@@ -25,6 +18,14 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	sinksgrpc "github.com/ns1labs/orb/sinks/api/grpc"
+	"github.com/opentracing/opentracing-go"
+	"github.com/spf13/viper"
+	jconfig "github.com/uber/jaeger-client-go/config"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/ns1labs/orb/maestro"
 	"github.com/ns1labs/orb/pkg/config"
@@ -220,8 +221,7 @@ func loadSinkerEsConfig(prefix string) config.EsConfig {
 
 	cfg.SetDefault("url", "localhost:6378")
 	cfg.SetDefault("pass", "")
-	cfg.SetDefault("db", "0")
-	cfg.SetDefault("consumer", fmt.Sprintf("%s-sinker-es-consumer", prefix))
+	cfg.SetDefault("db", "1")
 
 	cfg.AllowEmptyEnv(true)
 	cfg.AutomaticEnv()

--- a/maestro/kubecontrol/kubecontrol.go
+++ b/maestro/kubecontrol/kubecontrol.go
@@ -45,7 +45,10 @@ func (svc *deployService) collectorDeploy(ctx context.Context, operation, ownerI
 	fileContent := []byte(manifest)
 	tmp := strings.Split(string(fileContent), "\n")
 	newContent := strings.Join(tmp[1:], "\n")
-
+	
+	// we should control it internally using a map or redis for more maestro replicas, and not with k8s
+	// cuz its generating wrong status during sink update operation
+	// sink update operation is crucial for the system once that is responsible to permit user fix its otel collector in errored cases
 	if operation == "apply" {
 		if value, ok := svc.deploymentState[sinkId]; ok && value {
 			svc.logger.Info("Already applied Sink ID=" + sinkId)
@@ -79,6 +82,7 @@ func (svc *deployService) collectorDeploy(ctx context.Context, operation, ownerI
 
 	if err == nil {
 		svc.logger.Info(fmt.Sprintf("successfully %s the otel-collector for sink-id: %s", operation, sinkId))
+		// update deployment state map
 		if operation == "apply" {
 			svc.deploymentState[sinkId] = true
 		} else if operation == "delete" {

--- a/maestro/kubecontrol/kubecontrol.go
+++ b/maestro/kubecontrol/kubecontrol.go
@@ -46,9 +46,8 @@ func (svc *deployService) collectorDeploy(ctx context.Context, operation, ownerI
 	tmp := strings.Split(string(fileContent), "\n")
 	newContent := strings.Join(tmp[1:], "\n")
 	
-	// we should control it internally using a map or redis for more maestro replicas, and not with k8s
-	// cuz its generating wrong status during sink update operation due the delay in k8s api to answer
-	// sink update operation is crucial for the system once that is responsible to permit user fix its otel collector in errored cases
+	// due the delay in k8s api to answer, we should control it internally using a map or redis for more maestro replicas, and not with k8s
+	// otherwise can generate wrong deployment status during sink update operation
 	if operation == "apply" {
 		if value, ok := svc.deploymentState[sinkId]; ok && value {
 			svc.logger.Info("Already applied Sink ID=" + sinkId)

--- a/maestro/kubecontrol/kubecontrol.go
+++ b/maestro/kubecontrol/kubecontrol.go
@@ -47,7 +47,7 @@ func (svc *deployService) collectorDeploy(ctx context.Context, operation, ownerI
 	newContent := strings.Join(tmp[1:], "\n")
 	
 	// we should control it internally using a map or redis for more maestro replicas, and not with k8s
-	// cuz its generating wrong status during sink update operation
+	// cuz its generating wrong status during sink update operation due the delay in k8s api to answer
 	// sink update operation is crucial for the system once that is responsible to permit user fix its otel collector in errored cases
 	if operation == "apply" {
 		if value, ok := svc.deploymentState[sinkId]; ok && value {

--- a/maestro/kubecontrol/kubecontrol.go
+++ b/maestro/kubecontrol/kubecontrol.go
@@ -58,7 +58,7 @@ func (svc *deployService) collectorDeploy(ctx context.Context, operation, ownerI
 		}
 	}
 
-	err = os.WriteFile("/tmp/otel-collector-"+sinkId+".json", []byte(newContent), 0644)
+	err := os.WriteFile("/tmp/otel-collector-"+sinkId+".json", []byte(newContent), 0644)
 	if err != nil {
 		svc.logger.Error("failed to write file content", zap.Error(err))
 		return err

--- a/maestro/kubecontrol/monitor.go
+++ b/maestro/kubecontrol/monitor.go
@@ -172,9 +172,9 @@ func (svc *monitorService) monitorSinks(ctx context.Context) {
 		}
 		if sinkCollector == nil {
 			svc.logger.Warn("collector not found for sink, checking to set state as error", zap.String("sinkID", sink.Id))
-			// if collector dont spin up in 10 minutes should report error on collector deployment
+			// if collector dont spin up in 30 minutes should report error on collector deployment
 			svc.deploymentChecks[sink.Id]++
-			if svc.deploymentChecks[sink.Id] >= 10 {
+			if svc.deploymentChecks[sink.Id] >= 30 {
 				err := errors.New("permanent error: opentelemetry collector deployment error")
 				svc.publishSinkStateChange(sink, "error", err, err)
 				svc.deploymentChecks[sink.Id] = 0

--- a/maestro/kubecontrol/monitor.go
+++ b/maestro/kubecontrol/monitor.go
@@ -228,14 +228,11 @@ func (svc *monitorService) publishSinkStateChange(sink *sinkspb.SinkRes, status 
 }
 
 // analyzeLogs, will check for errors in exporter, and will return as follows
-//
-//		for active, the timestamp should not be longer than 5 minutes of the last metric export
-//		for errors 479 will send a "warning" state, plus message of too many requests
+//		for errors 429 will send a "warning" state, plus message of too many requests
 //		for any other errors, will add error and message
 //		if no error message on exporter, will log as active
 //	 logs from otel-collector are coming in the standard from https://pkg.go.dev/log,
 //
-// TODO changing the logs from otel-collector to a json format that we can read and check for errors, will affect this
 func (svc *monitorService) analyzeLogs(logEntry []string) (status string, err error) {
 		for _, logLine := range logEntry {
 		if len(logLine) > 24 {

--- a/maestro/kubecontrol/monitor.go
+++ b/maestro/kubecontrol/monitor.go
@@ -168,13 +168,8 @@ func (svc *monitorService) monitorSinks(ctx context.Context) {
 			svc.logger.Warn("failed to unmarshal sink config, skipping", zap.String("sink-id", sink.Id))
 			continue
 		}
-// 		if data.LastRemoteWrite.After(time.Now().Add(-TimeDiffActiveIdle)) {
-// 			svc.logger.Warn("collector recently updated, skipping", zap.String("sink-id", sink.Id))
-// 			continue
-// 		}
 		data.SinkID = sink.Id
 		data.OwnerID = sink.OwnerID
-		// data.LastRemoteWrite = time.Now()
 		logs, err := svc.getPodLogs(ctx, *sinkCollector)
 		if err != nil {
 			svc.logger.Error("error on getting logs, skipping", zap.Error(err))

--- a/maestro/kubecontrol/monitor.go
+++ b/maestro/kubecontrol/monitor.go
@@ -160,7 +160,8 @@ func (svc *monitorService) monitorSinks(ctx context.Context) {
 			}
 		}
 		if sinkCollector == nil {
-			svc.logger.Warn("collector not found for sink, skipping", zap.String("sinkID", sink.Id))
+			svc.logger.Warn("collector not found for sink, set state as error", zap.String("sinkID", sink.Id))
+			svc.publishSinkStateChange(sink, "error", "Permanent error: OpenTelemetry collector deployment error", errors.New("Permanent error: OpenTelemetry collector deployment error"))
 			continue
 		}
 		var data maestroconfig.SinkData

--- a/maestro/kubecontrol/monitor.go
+++ b/maestro/kubecontrol/monitor.go
@@ -161,7 +161,8 @@ func (svc *monitorService) monitorSinks(ctx context.Context) {
 		}
 		if sinkCollector == nil {
 			svc.logger.Warn("collector not found for sink, set state as error", zap.String("sinkID", sink.Id))
-			svc.publishSinkStateChange(sink, "error", "Permanent error: OpenTelemetry collector deployment error", errors.New("Permanent error: OpenTelemetry collector deployment error"))
+			err := errors.New("Permanent error: OpenTelemetry collector deployment error")
+			svc.publishSinkStateChange(sink, "error", err, err)
 			continue
 		}
 		var data maestroconfig.SinkData

--- a/maestro/kubecontrol/monitor.go
+++ b/maestro/kubecontrol/monitor.go
@@ -165,16 +165,16 @@ func (svc *monitorService) monitorSinks(ctx context.Context) {
 		}
 		var data maestroconfig.SinkData
 		if err := json.Unmarshal(sink.Config, &data); err != nil {
-			svc.logger.Warn("failed to unmarshal sink, skipping", zap.String("sink-id", sink.Id))
+			svc.logger.Warn("failed to unmarshal sink config, skipping", zap.String("sink-id", sink.Id))
 			continue
 		}
-		if data.LastRemoteWrite.After(time.Now().Add(-TimeDiffActiveIdle)) {
-			svc.logger.Warn("collector recently updated, skipping", zap.String("sink-id", sink.Id))
-			continue
-		}
+// 		if data.LastRemoteWrite.After(time.Now().Add(-TimeDiffActiveIdle)) {
+// 			svc.logger.Warn("collector recently updated, skipping", zap.String("sink-id", sink.Id))
+// 			continue
+// 		}
 		data.SinkID = sink.Id
 		data.OwnerID = sink.OwnerID
-		data.LastRemoteWrite = time.Now()
+		// data.LastRemoteWrite = time.Now()
 		logs, err := svc.getPodLogs(ctx, *sinkCollector)
 		if err != nil {
 			svc.logger.Error("error on getting logs, skipping", zap.Error(err))
@@ -189,8 +189,8 @@ func (svc *monitorService) monitorSinks(ctx context.Context) {
 		// this state can be 'error', if any error was found on otel collector during analyzeLogs() or
 		// we can set it as idle when we see that lastRemoteWrite is older than 30 minutes, however this 
 		// monitoring state function already exists on sinker
-		if data.State.String() == "active" {
-			if data.State.String() != status {
+		if sink.GetState() == "active" {
+			if sink.GetState() != status {
 				if err != nil {
 					svc.logger.Info("updating status", zap.Any("before", sink.GetState()), zap.String("new status", status), zap.String("error_message (opt)", err.Error()), zap.String("SinkID", sink.Id), zap.String("ownerID", sink.OwnerID))
 				} else {

--- a/maestro/service.go
+++ b/maestro/service.go
@@ -42,11 +42,10 @@ type maestroService struct {
 func NewMaestroService(logger *zap.Logger, streamRedisClient *redis.Client, sinkerRedisClient *redis.Client, sinksGrpcClient sinkspb.SinkServiceClient, esCfg config.EsConfig, otelCfg config.OtelConfig) Service {
 	kubectr := kubecontrol.NewService(logger, streamRedisClient)
 	eventStore := rediscons1.NewEventStore(streamRedisClient, otelCfg.KafkaUrl, kubectr, esCfg.Consumer, sinksGrpcClient, logger)
-	monitor := kubecontrol.NewMonitorService(logger, &sinksGrpcClient, streamRedisClient, &kubectr)
+	monitor := kubecontrol.NewMonitorService(logger, &sinksGrpcClient, streamRedisClient, sinkerRedisClient, &kubectr)
 	return &maestroService{
 		logger:            logger,
 		streamRedisClient: streamRedisClient,
-		sinkerRedisClient: sinkerRedisClient,
 		sinksClient:       sinksGrpcClient,
 		kubecontrol:       kubectr,
 		monitor:           monitor,

--- a/sinker/config/repo.go
+++ b/sinker/config/repo.go
@@ -15,4 +15,6 @@ type ConfigRepo interface {
 	GetAll(ownerID string) ([]SinkConfig, error)
 	GetAllOwners() ([]string, error)
 	DeployCollector(ctx context.Context, config SinkConfig) error
+	AddActivity(ownerID string, sinkID string) error
+	GetActivity(ownerID string, sinkID string) (int64, error)
 }

--- a/sinker/config_state_check.go
+++ b/sinker/config_state_check.go
@@ -35,17 +35,7 @@ func (svc *SinkerService) checkState(_ time.Time) {
 			// Set idle if the sinker is more than 30 minutes not sending metrics (Remove from Redis)
 			if cfg.LastRemoteWrite.Add(DefaultTimeout).Before(time.Now()) {
 				if cfg.State == config.Active {
-					if cfg.Opentelemetry == "enabled" {
-						err := cfg.State.SetFromString("idle")
-						if err != nil {
-							svc.logger.Error("error updating otel sink state", zap.Error(err))
-							return
-						}
-						if err := svc.sinkerCache.Edit(cfg); err != nil {
-							svc.logger.Error("error updating otel sink config cache to idle", zap.Error(err))
-							return
-						}
-					} else {
+					if cfg.Opentelemetry != "enabled" {
 						if err := svc.sinkerCache.Remove(cfg.OwnerID, cfg.SinkID); err != nil {
 							svc.logger.Error("error updating sink config cache", zap.Error(err))
 							return

--- a/sinker/otel/bridgeservice/bridge.go
+++ b/sinker/otel/bridgeservice/bridge.go
@@ -61,12 +61,7 @@ func (bs *SinkerOtelBridgeService) NotifyActiveSink(ctx context.Context, mfOwner
 			return err
 		}
 	} else {
-		// if status remains Active during regular metrics export just update LastRemoteWrite
-		if cfgRepo.State == config.Active {
-			bs.logger.Info("sink is already active, updating LastRemoteWrite")
-			cfgRepo.LastRemoteWrite = time.Now()
-		}
-		err = bs.sinkerCache.DeployCollector(ctx, cfgRepo)
+		bs.logger.Info("sink is already active, skipping")
 	}
 
 	return nil

--- a/sinker/otel/bridgeservice/bridge.go
+++ b/sinker/otel/bridgeservice/bridge.go
@@ -61,7 +61,15 @@ func (bs *SinkerOtelBridgeService) NotifyActiveSink(ctx context.Context, mfOwner
 			return err
 		}
 	} else {
-		bs.logger.Info("sink is already active, skipping")
+		// update LastRemoteWrite on redis sinker for this collector
+		if cfgRepo.State == config.Active {
+			bs.logger.Info("sink is already active, skipping")
+			err = bs.sinkerCache.AddActivity(mfOwnerId, sinkId)
+			if err != nil {
+				bs.logger.Error("error during update last remote write", zap.String("sinkId", sinkId), zap.Error(err))
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/sinker/otel/bridgeservice/bridge.go
+++ b/sinker/otel/bridgeservice/bridge.go
@@ -61,12 +61,8 @@ func (bs *SinkerOtelBridgeService) NotifyActiveSink(ctx context.Context, mfOwner
 			return err
 		}
 	} else {
-		// if status is Error during metrics export just update error message
-		if cfgRepo.State == config.Error {
-			bs.logger.Info("sink have error status, updating Msg")
-			cfgRepo.Msg = message
 		// if status remains Active during regular metrics export just update LastRemoteWrite
-		} else if cfgRepo.State == config.Active {
+		if cfgRepo.State == config.Active {
 			bs.logger.Info("sink is already active, updating LastRemoteWrite")
 			cfgRepo.LastRemoteWrite = time.Now()
 		}

--- a/sinker/redis/producer/streams.go
+++ b/sinker/redis/producer/streams.go
@@ -125,6 +125,14 @@ func (e eventStore) Edit(config config.SinkConfig) error {
 	return nil
 }
 
+func (e eventStore) GetActivity(ownerID string, sinkID string) (int64, error) {
+	return e.sinkCache.GetActivity(ownerID, sinkID)
+}
+
+func (e eventStore) AddActivity(ownerID string, sinkID string) error {
+	return e.sinkCache.AddActivity(ownerID, sinkID)
+}
+
 func (e eventStore) GetAll(ownerID string) ([]config.SinkConfig, error) {
 	return e.sinkCache.GetAll(ownerID)
 }


### PR DESCRIPTION
This PR changes:
- Added logic to change LastRemoteWrite parameter for active sinks when receive a metric on sinker
- Symplify AnalyzeLogs function to check only errors in otel collector logs
- Removed LastRemoteWrite change on maestro monitorSinks function
- Just change sink status on maestro if it is active
- Fix deployment status on maestro micro service, should be internally controlled and not checking k8s deployment state, cuz can generate wrong status during update sink operation
- Remove otel idle state control from otel-sinker microservice, and added it on maestro with different manner