### PR TITLE
inserting tag on test scenarios with error status on sink

### DIFF
--- a/python-test/features/integration.feature
+++ b/python-test/features/integration.feature
@@ -251,7 +251,7 @@ Scenario: Provision agent with tag matching existing group with multiple policie
         And 20 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
 
 
-@smoke
+@smoke @sink_status_error
 Scenario: Sink with invalid endpoint
     Given the Orb user has a registered account
         And the Orb user logs in
@@ -332,7 +332,7 @@ Scenario: Unapplying policies that failed by removing group
         And 0 dataset(s) have validity valid and 4 have validity invalid in 30 seconds
 
 
-@smoke
+@smoke @sink_status_error
 Scenario: Sink with invalid username
     Given the Orb user has a registered account
         And the Orb user logs in
@@ -352,7 +352,7 @@ Scenario: Sink with invalid username
         And 4 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
 
 
-@smoke
+@smoke @sink_status_error
 Scenario: Sink with invalid password
     Given the Orb user has a registered account
         And the Orb user logs in
@@ -904,7 +904,7 @@ Scenario: Remove agent (check dataset)
         And last container created is exited after 120 seconds
         And 2 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
 
-@smoke
+@smoke @sink_status_error
 Scenario: Edit sink active and use invalid remote host
     Given the Orb user has a registered account
         And the Orb user logs in
@@ -925,7 +925,7 @@ Scenario: Edit sink active and use invalid remote host
         And 10 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
 
 
-@smoke
+@smoke @sink_status_error
 Scenario: Edit sink active and use invalid username
     Given the Orb user has a registered account
         And the Orb user logs in
@@ -946,7 +946,7 @@ Scenario: Edit sink active and use invalid username
         And 10 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
 
 
-@smoke
+@smoke @sink_status_error
 Scenario: Edit sink active and use invalid password
     Given the Orb user has a registered account
         And the Orb user logs in
@@ -967,7 +967,7 @@ Scenario: Edit sink active and use invalid password
         And 10 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
 
 
-@smoke
+@smoke @sink_status_error
 Scenario: Edit sink with invalid username and use valid one
     Given the Orb user has a registered account
         And the Orb user logs in
@@ -989,7 +989,7 @@ Scenario: Edit sink with invalid username and use valid one
         And 4 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
 
 
-@smoke
+@smoke @sink_status_error
 Scenario: Edit sink with password and use valid one
     Given the Orb user has a registered account
         And the Orb user logs in


### PR DESCRIPTION
Those tests must pass locally using OTEL config on test_config. 
behavex -t @sink_status_error --parallel-processes=20 --parallel-scheme=scenario