### PR TITLE
[ORB-673] Set default path for orb-agent.db

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -143,7 +143,7 @@ func mergeOrError(path string) {
 	v.SetDefault("orb.cloud.mqtt.id", "")
 	v.SetDefault("orb.cloud.mqtt.key", "")
 	v.SetDefault("orb.cloud.mqtt.channel_id", "")
-	v.SetDefault("orb.db.file", "./orb-agent.db")
+	v.SetDefault("orb.db.file", "/opt/orb/orb-agent.db")
 	v.SetDefault("orb.tls.verify", true)
 	v.SetDefault("orb.otel.enable", false)
 	v.SetDefault("orb.debug.enable", false)


### PR DESCRIPTION
This PR set the default path for orb-agent.db to /opt/orb/
![image](https://user-images.githubusercontent.com/97463920/219041668-a42819fd-4be8-404e-82f8-3b6920011137.png)
