### PR TITLE
Update agent.example.yaml

### DIFF
--- a/cmd/agent/agent.example.yaml
+++ b/cmd/agent/agent.example.yaml
@@ -4,7 +4,7 @@ version: "1.0"
 # see https://github.com/orb-community/pktvisor/blob/develop/RFCs/2021-04-16-75-taps.md
 visor:
   taps:
-    mydefault:
+    default_pcap:
       input_type: pcap
       config:
         iface: "auto"


### PR DESCRIPTION
this came after my session with Xin.. the default policy failed to be applied because of the tap name.. so i think its worth keeping the pattern