### PR TITLE
fix(build:ui): read GTAG from environment variable

### DIFF
--- a/ui/scripts/setenv.ts
+++ b/ui/scripts/setenv.ts
@@ -31,10 +31,20 @@ const enableMaintenace = () => {
   }
 };
 
+const enableGTAG = () => {
+  if (process.env.GTAGID) {
+    return `
+    GTAGID: '${ process.env.GTAGID }',
+    `;
+  } else {
+    return '';
+  }
+};
+
 // we have access to our environment variables
 // in the process.env object thanks to dotenv
 const environmentFileContent = `
-export const environment = {${enablePS()}${enableMaintenace()}};
+export const environment = {${enablePS()}${enableMaintenace()}${enableGTAG()}};
 `;
 
 // write the content to the respective file

--- a/ui/src/environments/environment.prod.beta.ts
+++ b/ui/src/environments/environment.prod.beta.ts
@@ -5,7 +5,7 @@ const {orbApi: {apiUrl, version, urlKeys, servicesUrls}} = defaultEnvironment;
 
 export const environment = {
   production: true,
-  GTAGID: 'G-T0RBPQ9HSJ',
+  GTAGID: '',
   ...defaultEnvironment,
   ...envVars,
   // ORB api --prod

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -5,7 +5,7 @@ const {orbApi: {apiUrl, version, urlKeys, servicesUrls}} = defaultEnvironment;
 
 export const environment = {
   production: true,
-  GTAGID: 'G-T0RBPQ9HSJ',
+  GTAGID: '',
   ...defaultEnvironment,
   ...envVars,
   // ORB api --prod


### PR DESCRIPTION
Changed https://github.com/orb-community/orb/blob/develop/ui/scripts/setenv.ts to read GTAGID value from environment and write it to https://github.com/orb-community/orb/blob/develop/ui/src/environments/environment.env.ts upon build.

[] requires GTAGID to be defined on build environment