### PR TITLE
fix(sinker): add logger to eventstore.

### DIFF
--- a/cmd/sinker/main.go
+++ b/cmd/sinker/main.go
@@ -168,7 +168,7 @@ func main() {
 	sinksGRPCClient := sinksgrpc.NewClient(tracer, sinksGRPCConn, sinksGRPCTimeout, logger)
 
 	configRepo := cacheconfig.NewSinkerCache(cacheClient, logger)
-	configRepo = producer.NewEventStoreMiddleware(configRepo, esClient)
+	configRepo = producer.NewEventStoreMiddleware(configRepo, esClient, logger)
 	gauge := kitprometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 		Namespace: "sinker",
 		Subsystem: "sink",

--- a/sinker/redis/producer/streams.go
+++ b/sinker/redis/producer/streams.go
@@ -142,9 +142,10 @@ func (e eventStore) GetAllOwners() ([]string, error) {
 	return e.sinkCache.GetAllOwners()
 }
 
-func NewEventStoreMiddleware(repo config.ConfigRepo, client *redis.Client) config.ConfigRepo {
+func NewEventStoreMiddleware(repo config.ConfigRepo, client *redis.Client, logger *zap.Logger) config.ConfigRepo {
 	return eventStore{
 		sinkCache: repo,
 		client:    client,
+		logger:    logger,
 	}
 }


### PR DESCRIPTION
Hotfix in sinker logging was not being initialized in redis/producer/streams.go