### PR TITLE
removing sink status check of flow without metrics

### DIFF
--- a/python-test/features/integration.feature
+++ b/python-test/features/integration.feature
@@ -291,7 +291,7 @@ Scenario: Sink idle after 5 minutes without metrics flow
     When stop the orb-agent container
     Then referred sink must have idle state on response after 660 seconds
 
-@smoke @sink_status_error
+@sanity @sink_status_error
 Scenario: Sink with invalid endpoint
     Given the Orb user has a registered account
         And the Orb user logs in
@@ -1007,7 +1007,7 @@ Scenario: Edit sink active and use invalid password
         And 10 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
 
 
-@smoke @sink_status_error
+@sanity @sink_status_error
 Scenario: Edit sink with invalid username and use valid one
     Given the Orb user has a registered account
         And the Orb user logs in
@@ -1029,7 +1029,7 @@ Scenario: Edit sink with invalid username and use valid one
         And 4 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
 
 
-@smoke @sink_status_error
+@sanity @sink_status_error
 Scenario: Edit sink with password and use valid one
     Given the Orb user has a registered account
         And the Orb user logs in
@@ -1328,7 +1328,7 @@ Scenario: Partial Update: sink status after updating only sink name, description
 
 
 
-@sanity@sink_partial_update
+@sanity @sink_partial_update
 Scenario: Partial Update: sink status after updating only sink name, description and configs
     Given the Orb user has a registered account
         And the Orb user logs in

--- a/python-test/features/integration_config_file.feature
+++ b/python-test/features/integration_config_file.feature
@@ -38,7 +38,6 @@ Scenario: provisioning agent without specify pktvisor binary path and path to co
         And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And referred sink must have active state on response within 120 seconds
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -58,7 +57,6 @@ Scenario: provisioning agent without specify pktvisor binary path (config file -
         And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And referred sink must have active state on response within 120 seconds
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -78,7 +76,6 @@ Scenario: provisioning agent without specify pktvisor path to config file (confi
         And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And referred sink must have active state on response within 120 seconds
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -98,7 +95,6 @@ Scenario: provisioning agent without specify pktvisor binary path and path to co
         And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And referred sink must have active state on response within 120 seconds
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -120,7 +116,6 @@ Scenario: provisioning agent without specify pktvisor binary path (config file -
         And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And referred sink must have active state on response within 120 seconds
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -142,7 +137,6 @@ Scenario: provisioning agent without specify pktvisor path to config file (confi
         And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And referred sink must have active state on response within 120 seconds
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -430,7 +424,6 @@ Scenario: agent flow with only agent tags subscription to a group with policies 
         And this agent's heartbeat shows that 1 groups are matching the agent
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And referred sink must have active state on response within 120 seconds
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -450,7 +443,6 @@ Scenario: agent flow with only agent tags subscription to a group with policies 
         And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And referred sink must have active state on response within 120 seconds
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -470,7 +462,6 @@ Scenario: agent flow with mixed tags subscription to a group with policies creat
         And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And referred sink must have active state on response within 120 seconds
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -490,7 +481,6 @@ Scenario: agent flow with mixed tags subscription to a group with policies creat
         And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And referred sink must have active state on response within 120 seconds
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -509,7 +499,6 @@ Scenario: agent flow with only agent tags subscription to a group with policies 
         And this agent's heartbeat shows that 1 groups are matching the agent
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And referred sink must have active state on response within 120 seconds
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -549,7 +538,6 @@ Scenario: agent flow with mixed tags subscription to a group with policies creat
         And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And referred sink must have active state on response within 120 seconds
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And remove the agent .yaml generated on each scenario
 


### PR DESCRIPTION
i'm removing sink status check of scenarios with flow without metrics.. sanity tests are now running on pipeline and we have validations with metrics there