### PR TITLE
fix(sinks): overall sinks fixes with custom headers and a few sanity tests fixes

### DIFF
--- a/maestro/config/exporter_builder.go
+++ b/maestro/config/exporter_builder.go
@@ -51,11 +51,23 @@ type OTLPHTTPExporterBuilder struct {
 }
 
 func (O *OTLPHTTPExporterBuilder) GetExportersFromMetadata(config types.Metadata, authenticationExtensionName string) (Exporters, string) {
-	endpointCfg := config.GetSubMetadata("exporter")["endpoint"].(string)
-	return Exporters{
-		OTLPExporter: &OTLPExporterConfig{
-			Endpoint: endpointCfg,
-			Auth:     Auth{Authenticator: authenticationExtensionName},
-		},
-	}, "otlphttp"
+	exporterSubMeta := config.GetSubMetadata("exporter")
+	endpointCfg := exporterSubMeta["endpoint"].(string)
+	customHeaders, ok := exporterSubMeta["headers"]
+	if !ok || customHeaders == nil {
+		return Exporters{
+			OTLPExporter: &OTLPExporterConfig{
+				Endpoint: endpointCfg,
+				Auth:     Auth{Authenticator: authenticationExtensionName},
+			},
+		}, "otlphttp"
+	} else {
+		return Exporters{
+			OTLPExporter: &OTLPExporterConfig{
+				Endpoint: endpointCfg,
+				Auth:     Auth{Authenticator: authenticationExtensionName},
+				Headers:  customHeaders.(map[string]interface{}),
+			},
+		}, "otlphttp"
+	}
 }

--- a/maestro/config/types.go
+++ b/maestro/config/types.go
@@ -134,7 +134,8 @@ type LoggingExporterConfig struct {
 }
 
 type OTLPExporterConfig struct {
-	Endpoint string `json:"endpoint" yaml:"endpoint"`
+	Endpoint string                 `json:"endpoint" yaml:"endpoint"`
+	Headers  map[string]interface{} `json:"headers,omitempty" yaml:"headers,omitempty"`
 	Auth     struct {
 		Authenticator string `json:"authenticator" yaml:"authenticator"`
 	}

--- a/sinker/config/types.go
+++ b/sinker/config/types.go
@@ -6,24 +6,15 @@ package config
 
 import (
 	"database/sql/driver"
+	"github.com/orb-community/orb/pkg/types"
 	"time"
 )
 
 // SinkConfigParser to be compatible with new sinks config is coming from eventbus
 type SinkConfig struct {
-	SinkID         string `json:"sink_id"`
-	OwnerID        string `json:"owner_id"`
-	Authentication struct {
-		Type     string `json:"type"`
-		Password string `json:"password"`
-		Username string `json:"username"`
-	} `json:"authentication"`
-	Exporter struct {
-		RemoteHost *string           `json:"remote_host",omitempty`
-		Endpoint   *string           `json:"endpoint",omitempty`
-		Headers    map[string]string `json:"headers",omitempty`
-	} `json:"exporter"`
-	OpenTelemetry   string          `json:"opentelemetry"`
+	SinkID          string          `json:"sink_id"`
+	OwnerID         string          `json:"owner_id"`
+	Config          types.Metadata  `json:"config"`
 	State           PrometheusState `json:"state,omitempty"`
 	Msg             string          `json:"msg,omitempty"`
 	LastRemoteWrite time.Time       `json:"last_remote_write,omitempty"`

--- a/sinker/config/types.go
+++ b/sinker/config/types.go
@@ -19,7 +19,9 @@ type SinkConfig struct {
 		Username string `json:"username"`
 	} `json:"authentication"`
 	Exporter struct {
-		RemoteHost string `json:"remote_host"`
+		RemoteHost *string           `json:"remote_host",omitempty`
+		Endpoint   *string           `json:"endpoint",omitempty`
+		Headers    map[string]string `json:"headers",omitempty`
 	} `json:"exporter"`
 	OpenTelemetry   string          `json:"opentelemetry"`
 	State           PrometheusState `json:"state,omitempty"`

--- a/sinker/config_state_check.go
+++ b/sinker/config_state_check.go
@@ -35,7 +35,7 @@ func (svc *SinkerService) checkState(_ time.Time) {
 			// Set idle if the sinker is more than 30 minutes not sending metrics (Remove from Redis)
 			if cfg.LastRemoteWrite.Add(DefaultTimeout).Before(time.Now()) {
 				if cfg.State == config.Active {
-					if cfg.OpenTelemetry != "enabled" {
+					if v, ok := cfg.Config["opentelemetry"]; !ok || v != "enabled" {
 						if err := svc.sinkerCache.Remove(cfg.OwnerID, cfg.SinkID); err != nil {
 							svc.logger.Error("error updating sink config cache", zap.Error(err))
 							return

--- a/sinker/config_state_check.go
+++ b/sinker/config_state_check.go
@@ -15,7 +15,7 @@ const (
 	streamID       = "orb.sinker"
 	streamLen      = 1000
 	CheckerFreq    = 5 * time.Minute
-	DefaultTimeout = 30 * time.Minute
+	DefaultTimeout = 5 * time.Minute
 )
 
 func (svc *SinkerService) checkState(_ time.Time) {

--- a/sinker/message_handler.go
+++ b/sinker/message_handler.go
@@ -34,7 +34,7 @@ func (svc SinkerService) remoteWriteToPrometheus(tsList prometheus.TSList, owner
 		ctx = context.WithValue(ctx, "deprecation", "opentelemetry")
 	}
 	cfg := prometheus.NewConfig(
-		prometheus.WriteURLOption(cfgRepo.Exporter.RemoteHost),
+		prometheus.WriteURLOption(*cfgRepo.Exporter.RemoteHost),
 	)
 
 	promClient, err := prometheus.NewClient(cfg)
@@ -62,7 +62,8 @@ func (svc SinkerService) remoteWriteToPrometheus(tsList prometheus.TSList, owner
 		return err
 	}
 
-	svc.logger.Debug("successful sink", zap.Int("payload_size_b", result.PayloadSize), zap.String("sink_id", sinkID), zap.String("url", cfgRepo.Exporter.RemoteHost), zap.String("user", cfgRepo.Authentication.Username))
+	svc.logger.Debug("successful sink", zap.Int("payload_size_b", result.PayloadSize),
+		zap.String("sink_id", sinkID))
 
 	if cfgRepo.State != config.Active {
 		cfgRepo.State = config.Active

--- a/sinker/message_handler.go
+++ b/sinker/message_handler.go
@@ -29,12 +29,18 @@ func (svc SinkerService) remoteWriteToPrometheus(tsList prometheus.TSList, owner
 		return err
 	}
 	ctx := context.Background()
-	if cfgRepo.OpenTelemetry == "enabled" {
+	otelMetadata, ok := cfgRepo.Config["opentelemetry"]
+	if ok && otelMetadata == "enabled" {
 		svc.logger.Info("deprecate warning opentelemetry sink scraping legacy agent", zap.String("sink-ID", cfgRepo.SinkID))
 		ctx = context.WithValue(ctx, "deprecation", "opentelemetry")
 	}
+	configMetadata := cfgRepo.Config.GetSubMetadata("exporter")
+	if configMetadata == nil {
+		svc.logger.Error("unable to find prometheus remote host", zap.Error(err))
+		return err
+	}
 	cfg := prometheus.NewConfig(
-		prometheus.WriteURLOption(*cfgRepo.Exporter.RemoteHost),
+		prometheus.WriteURLOption(configMetadata["remote_host"].(string)),
 	)
 
 	promClient, err := prometheus.NewClient(cfg)
@@ -42,9 +48,13 @@ func (svc SinkerService) remoteWriteToPrometheus(tsList prometheus.TSList, owner
 		svc.logger.Error("unable to construct client", zap.Error(err))
 		return err
 	}
-
+	authMetadata := cfgRepo.Config.GetSubMetadata("authentication")
+	if authMetadata == nil {
+		svc.logger.Error("unable to find prometheus remote host", zap.Error(err))
+		return err
+	}
 	var headers = make(map[string]string)
-	headers["Authorization"] = svc.encodeBase64(cfgRepo.Authentication.Username, cfgRepo.Authentication.Password)
+	headers["Authorization"] = svc.encodeBase64(authMetadata["username"].(string), authMetadata["password"].(string))
 	result, writeErr := promClient.WriteTimeSeries(ctx, tsList, prometheus.WriteOptions{Headers: headers})
 	if err := error(writeErr); err != nil {
 		if cfgRepo.Msg != fmt.Sprint(err) {

--- a/sinker/redis/consumer/streams.go
+++ b/sinker/redis/consumer/streams.go
@@ -172,11 +172,9 @@ func (es eventStore) handleSinksUpdate(_ context.Context, e updateSinkEvent) err
 		if err != nil {
 			return err
 		}
-		sinkConfig.Authentication.Type = cfg.Authentication.Type
-		sinkConfig.Authentication.Username = cfg.Authentication.Username
-		sinkConfig.Authentication.Password = cfg.Authentication.Password
-		sinkConfig.Exporter.RemoteHost = cfg.Exporter.RemoteHost
-		sinkConfig.OpenTelemetry = cfg.OpenTelemetry
+		if sinkConfig.Config == nil {
+			sinkConfig.Config = cfg.Config
+		}
 		if sinkConfig.OwnerID == "" {
 			sinkConfig.OwnerID = e.owner
 		}

--- a/sinker/redis/consumer/streams.go
+++ b/sinker/redis/consumer/streams.go
@@ -150,6 +150,7 @@ func (es eventStore) handleSinksRemove(_ context.Context, e updateSinkEvent) err
 	if ok := es.configRepo.Exists(e.owner, e.sinkID); ok {
 		err := es.configRepo.Remove(e.owner, e.sinkID)
 		if err != nil {
+			es.logger.Error("error during remove sinker cache entry", zap.Error(err))
 			return err
 		}
 	}

--- a/sinks/backend/prometheus/configuration.go
+++ b/sinks/backend/prometheus/configuration.go
@@ -61,7 +61,7 @@ func (p *Backend) ValidateConfiguration(config types.Metadata) error {
 	if customHeadersOk {
 		headersAsMap := customHeaders.(map[string]interface{})
 		for _, header := range invalidCustomHeaders {
-			if _, ok := headersAsMap[header]; !ok {
+			if _, ok := headersAsMap[header]; ok {
 				return errors.New("invalid custom headers")
 			}
 		}

--- a/sinks/sinks_service.go
+++ b/sinks/sinks_service.go
@@ -91,7 +91,7 @@ func validateAuthType(s *Sink) (authentication_type.AuthenticationType, error) {
 	}
 	authTypeStr, ok := authMetadata["type"]
 	if !ok {
-		return nil, errors.Wrap(errors.ErrAuthTypeNotFound, errors.New("authentication type not found")) 
+		return nil, errors.Wrap(errors.ErrAuthTypeNotFound, errors.New("authentication type not found"))
 	}
 
 	if _, ok := authTypeStr.(string); !ok {
@@ -341,11 +341,11 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 	}
 	err = svc.sinkRepo.Update(ctx, sink)
 	if err != nil {
-		return Sink{}, errors.Wrap(ErrUpdateEntity, err)
+		return Sink{}, err
 	}
 	sinkEdited, err := svc.sinkRepo.RetrieveById(ctx, sink.ID)
 	if err != nil {
-		return Sink{}, errors.Wrap(ErrUpdateEntity, err)
+		return Sink{}, err
 	}
 	sinkEdited, err = svc.decryptMetadata(cfg, sinkEdited)
 	if err != nil {

--- a/sinks/sinks_service.go
+++ b/sinks/sinks_service.go
@@ -295,11 +295,11 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 		sink.Backend = currentSink.Backend
 		be, err := validateBackend(&sink)
 		if err != nil {
-			return Sink{}, errors.Wrap(ErrMalformedEntity, err)
+			return Sink{}, errors.Wrap(errors.New("incorrect backend and exporter configuration"), err)
 		}
 		at, err := validateAuthType(&sink)
 		if err != nil {
-			return Sink{}, errors.Wrap(ErrMalformedEntity, err)
+			return Sink{}, errors.Wrap(errors.New("incorrect authentication configuration"), err)
 		}
 		cfg = Configuration{
 			Authentication: at,
@@ -313,7 +313,8 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 		if sink.Format == "yaml" {
 			configDataByte, err := yaml.Marshal(sink.Config)
 			if err != nil {
-				return Sink{}, errors.Wrap(ErrMalformedEntity, err)
+				svc.logger.Error("failed to marshal config data", zap.Error(err))
+				return Sink{}, errors.Wrap(errors.New("configuration is invalid for yaml format"), err)
 			}
 			sink.ConfigData = string(configDataByte)
 		}


### PR DESCRIPTION
Fixed Custom Headers 
Deployment with config yaml
```
receivers:
  kafka:
    brokers:
    - kind-orb-kafka.orb.svc.cluster.local:9092
    topic: otlp_metrics-b382f72e-14da-4284-9bad-627136c61e2b
    protocol_version: 2.0.0
extensions:
  pprof:
    endpoint: 0.0.0.0:1888
  basicauth/exporter:
    client_auth:
      username: username
      password:password 
exporters:
  prometheusremotewrite:
    endpoint: https://localhost
    headers:
      X-Tenant: MY_TENANT_1
    auth:
      authenticator: basicauth/exporter
service:
  extensions:
  - pprof
  - basicauth/exporter
  pipelines:
    metrics:
      receivers:
      - kafka
      exporters:
      - prometheusremotewrite
```