### PR TITLE
feat(cmd): unblock services due to failure on jaeger.

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -225,8 +225,7 @@ func initJaeger(svcName, url string, logger *zap.Logger) (opentracing.Tracer, io
 		},
 	}.NewTracer()
 	if err != nil {
-		logger.Error("Failed to init Jaeger client", zap.Error(err))
-		os.Exit(1)
+		logger.Error("Failed to init Jaeger client, tracing will be disabled", zap.Error(err))
 	}
 
 	return tracer, closer

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -178,8 +178,7 @@ func initJaeger(svcName, url string, logger *zap.Logger) (opentracing.Tracer, io
 		},
 	}.NewTracer()
 	if err != nil {
-		logger.Error("Failed to init Jaeger client", zap.Error(err))
-		os.Exit(1)
+		logger.Error("Failed to init Jaeger client, tracing will be disabled", zap.Error(err))
 	}
 
 	return tracer, closer

--- a/cmd/policies/main.go
+++ b/cmd/policies/main.go
@@ -190,8 +190,7 @@ func initJaeger(svcName, url string, logger *zap.Logger) (opentracing.Tracer, io
 		},
 	}.NewTracer()
 	if err != nil {
-		logger.Error("Failed to init Jaeger client", zap.Error(err))
-		os.Exit(1)
+		logger.Error("Failed to init Jaeger client, tracing will be disabled", zap.Error(err))
 	}
 
 	return tracer, closer

--- a/cmd/sinks/main.go
+++ b/cmd/sinks/main.go
@@ -177,8 +177,7 @@ func initJaeger(svcName, url string, logger *zap.Logger) (opentracing.Tracer, io
 		},
 	}.NewTracer()
 	if err != nil {
-		logger.Error("Failed to init Jaeger client", zap.Error(err))
-		os.Exit(1)
+		logger.Error("Failed to init Jaeger client, tracing will be disabled", zap.Error(err))
 	}
 
 	return tracer, closer


### PR DESCRIPTION
Removing the block for not starting the service when jaeger client fails.

Just need to validate the functionality after a failure, it may impact because go-kit uses directly the tracer, we might need to have a noop tracer at hand there.