### PR TITLE
fix (maestro): activity and error event synchronization

### DIFF
--- a/maestro/deployment/service.go
+++ b/maestro/deployment/service.go
@@ -153,7 +153,7 @@ func (d *deploymentService) UpdateDeployment(ctx context.Context, deployment *De
 		return err
 	}
 	got.LastCollectorStopTime = &now
-	codedConfig, err := d.encodeConfig(got)
+	codedConfig, err := d.encodeConfig(deployment)
 	if err != nil {
 		return err
 	}

--- a/maestro/kubecontrol/kubecontrol.go
+++ b/maestro/kubecontrol/kubecontrol.go
@@ -96,8 +96,8 @@ func (svc *deployService) collectorDeploy(ctx context.Context, operation, ownerI
 	}
 
 	// delete temporary file
-	err = os.Remove("/tmp/otel-collector-"+sinkId+".json")
-
+	os.Remove("/tmp/otel-collector-"+sinkId+".json")
+	
 	// TODO this will be retrieved once we move to K8s SDK
 	collectorName := fmt.Sprintf("otel-%s", sinkId)
 	return collectorName, nil
@@ -142,7 +142,7 @@ func (svc *deployService) getDeploymentState(ctx context.Context, _, sinkId stri
 		}
 	}
 	status = "deleted"
-	return "", "deleted", nil
+	return "", status, nil
 }
 
 func (svc *deployService) CreateOtelCollector(ctx context.Context, ownerID, sinkID, deploymentEntry string) (string, error) {

--- a/maestro/kubecontrol/kubecontrol.go
+++ b/maestro/kubecontrol/kubecontrol.go
@@ -61,7 +61,7 @@ type Service interface {
 	CreateOtelCollector(ctx context.Context, ownerID, sinkID, deploymentEntry string) (string, error)
 
 	// KillOtelCollector - kill an existing collector by id, terminating by the ownerID, sinkID without the file
-	KillOtelCollector(ctx context.Context, deploymentName, sinkID string) error
+	KillOtelCollector(ctx context.Context, ownerID, sinkId, deploymentEntry string) error
 }
 
 func (svc *deployService) collectorDeploy(ctx context.Context, operation, ownerID, sinkId, manifest string) (string, error) {

--- a/maestro/kubecontrol/kubecontrol.go
+++ b/maestro/kubecontrol/kubecontrol.go
@@ -97,7 +97,7 @@ func (svc *deployService) collectorDeploy(ctx context.Context, operation, ownerI
 
 	// delete temporary file
 	os.Remove("/tmp/otel-collector-"+sinkId+".json")
-	
+
 	// TODO this will be retrieved once we move to K8s SDK
 	collectorName := fmt.Sprintf("otel-%s", sinkId)
 	return collectorName, nil

--- a/maestro/redis/consumer/sinker.go
+++ b/maestro/redis/consumer/sinker.go
@@ -38,7 +38,7 @@ func (s *sinkerActivityListenerService) SubscribeSinksActivity(ctx context.Conte
 	if err != nil && err.Error() != maestroredis.Exists {
 		return err
 	}
-	s.logger.Debug("Reading Sinks Activity Events", zap.String("stream", activityStream))
+	s.logger.Debug("Reading Sinker Activity Events", zap.String("stream", activityStream))
 	for {
 		select {
 		case <-ctx.Done():
@@ -87,6 +87,7 @@ func (s *sinkerActivityListenerService) SubscribeSinksIdle(ctx context.Context) 
 	if err != nil && err.Error() != maestroredis.Exists {
 		return err
 	}
+	s.logger.Debug("Reading Sinker Idle Events", zap.String("stream", idleStream))
 	for {
 		select {
 		case <-ctx.Done():

--- a/maestro/redis/consumer/sinker.go
+++ b/maestro/redis/consumer/sinker.go
@@ -2,15 +2,20 @@ package consumer
 
 import (
 	"context"
+
 	"github.com/go-redis/redis/v8"
 	maestroredis "github.com/orb-community/orb/maestro/redis"
 	"github.com/orb-community/orb/maestro/service"
+	redis2 "github.com/orb-community/orb/sinks/redis"
 	"go.uber.org/zap"
 )
 
 type SinkerActivityListener interface {
 	// SubscribeSinksEvents - listen to sink_activity, sink_idle because of state management and deployments start or stop
-	SubscribeSinksEvents(ctx context.Context) error
+	SubscribeSinkerIdleEvents(ctx context.Context) error
+
+	// SubscribeSinksEvents - listen to sink_activity
+	SubscribeSinkerActivityEvents(ctx context.Context) error
 }
 
 type sinkerActivityListenerService struct {
@@ -28,44 +33,43 @@ func NewSinkerActivityListener(l *zap.Logger, eventService service.EventService,
 	}
 }
 
-func (s *sinkerActivityListenerService) ReadSinksActivity(ctx context.Context) error {
+func (s *sinkerActivityListenerService) SubscribeSinksActivity(ctx context.Context) error {
 	const activityStream = "orb.sink_activity"
 	err := s.redisClient.XGroupCreateMkStream(ctx, activityStream, maestroredis.GroupMaestro, "$").Err()
 	if err != nil && err.Error() != maestroredis.Exists {
 		return err
 	}
-	go func() {
+	s.logger.Debug("Reading Sinks Activity Events", zap.String("stream", redis2.StreamSinks))
 		for {
-			streams, err := s.redisClient.XReadGroup(ctx, &redis.XReadGroupArgs{
-				Group:    maestroredis.GroupMaestro,
-				Consumer: "orb_maestro-es-consumer",
-				Streams:  []string{activityStream, ">"},
-			}).Result()
-			if err != nil || len(streams) == 0 {
-				if err != nil {
-					s.logger.Error("error reading activity stream", zap.Error(err))
+				streams, err := s.redisClient.XReadGroup(ctx, &redis.XReadGroupArgs{
+					Group:    maestroredis.GroupMaestro,
+					Consumer: "orb_maestro-es-consumer",
+					Streams:  []string{activityStream, ">"},
+					Count:    1000,
+				}).Result()
+				if err != nil || len(streams) == 0 {
+					if err != nil {
+						s.logger.Error("error reading activity stream", zap.Error(err))
+					}
+					continue
 				}
-				continue
-			}
-			for _, msg := range streams[0].Messages {
-				event := maestroredis.SinkerUpdateEvent{}
-				event.Decode(msg.Values)
-				s.logger.Debug("Reading message from activity stream",
-					zap.String("message_id", msg.ID),
-					zap.String("sink_id", event.SinkID),
-					zap.String("owner_id", event.OwnerID))
-				err := s.eventService.HandleSinkActivity(ctx, event)
-				if err != nil {
-					s.logger.Error("error receiving message", zap.Error(err))
-					return
+				for _, msg := range streams[0].Messages {
+					event := maestroredis.SinkerUpdateEvent{}
+					event.Decode(msg.Values)
+					s.logger.Debug("Reading message from activity stream",
+						zap.String("message_id", msg.ID),
+						zap.String("sink_id", event.SinkID),
+						zap.String("owner_id", event.OwnerID))
+					err := s.eventService.HandleSinkActivity(ctx, event)
+					if err != nil {
+						s.logger.Error("error receiving message", zap.Error(err))
+						return err
+					}
 				}
 			}
-		}
-	}()
-	return nil
 }
 
-func (s *sinkerActivityListenerService) ReadSinksIdle(ctx context.Context) error {
+func (s *sinkerActivityListenerService) SubscribeSinksIdle(ctx context.Context) error {
 	const idleStream = "orb.sink_idle"
 	err := s.redisClient.XGroupCreateMkStream(ctx, idleStream, maestroredis.GroupMaestro, "$").Err()
 	if err != nil && err.Error() != maestroredis.Exists {
@@ -102,19 +106,18 @@ func (s *sinkerActivityListenerService) ReadSinksIdle(ctx context.Context) error
 	return nil
 }
 
-func (s *sinkerActivityListenerService) SubscribeSinksEvents(ctx context.Context) error {
-	go func() {
-		err := s.ReadSinksActivity(ctx)
-		if err != nil {
-			s.logger.Error("error reading activity stream", zap.Error(err))
-		}
-	}()
-	go func() {
-		err := s.ReadSinksIdle(ctx)
-		if err != nil {
-			s.logger.Error("error reading idle stream", zap.Error(err))
-		}
-	}()
+func (s *sinkerActivityListenerService) SubscribeSinkerActivityEvents(ctx context.Context) error {
+	err := s.SubscribeSinksActivity(ctx)
+	if err != nil {
+		s.logger.Error("error reading activity stream", zap.Error(err))
+	}
+}
+
+func (s *sinkerActivityListenerService) SubscribeSinkerIdleEvents(ctx context.Context) error {
+	err := s.SubscribeSinksIdle(ctx)
+	if err != nil {
+		s.logger.Error("error reading idle stream", zap.Error(err))
+	}
 	return nil
 }
 

--- a/maestro/redis/consumer/sinker.go
+++ b/maestro/redis/consumer/sinker.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-redis/redis/v8"
 	maestroredis "github.com/orb-community/orb/maestro/redis"
 	"github.com/orb-community/orb/maestro/service"
-	redis2 "github.com/orb-community/orb/sinks/redis"
 	"go.uber.org/zap"
 )
 
@@ -39,7 +38,7 @@ func (s *sinkerActivityListenerService) SubscribeSinksActivity(ctx context.Conte
 	if err != nil && err.Error() != maestroredis.Exists {
 		return err
 	}
-	s.logger.Debug("Reading Sinks Activity Events", zap.String("stream", redis2.StreamSinks))
+	s.logger.Debug("Reading Sinks Activity Events", zap.String("stream", activityStream))
 		for {
 				streams, err := s.redisClient.XReadGroup(ctx, &redis.XReadGroupArgs{
 					Group:    maestroredis.GroupMaestro,

--- a/maestro/service.go
+++ b/maestro/service.go
@@ -134,5 +134,5 @@ func (svc *maestroService) subscribeToSinkerActivityEvents(ctx context.Context) 
 	if err := svc.activityListener.SubscribeSinkerActivityEvents(ctx); err != nil {
 		svc.logger.Error("Bootstrap service failed to subscribe to event sourcing", zap.Error(err))
 	}
-	s.logger.Info("finished reading sinker_activity events")
+	svc.logger.Info("finished reading sinker_activity events")
 }

--- a/maestro/service.go
+++ b/maestro/service.go
@@ -127,14 +127,12 @@ func (svc *maestroService) subscribeToSinkerIdleEvents(ctx context.Context) {
 	if err := svc.activityListener.SubscribeSinkerIdleEvents(ctx); err != nil {
 		svc.logger.Error("Bootstrap service failed to subscribe to event sourcing", zap.Error(err))
 	}
-	svc.logger.Info("finished reading sinker Idle events")
-	ctx.Done()
+	svc.logger.Info("finished reading sinker_idle events")
 }
 
 func (svc *maestroService) subscribeToSinkerActivityEvents(ctx context.Context) {
 	if err := svc.activityListener.SubscribeSinkerActivityEvents(ctx); err != nil {
 		svc.logger.Error("Bootstrap service failed to subscribe to event sourcing", zap.Error(err))
 	}
-	svc.logger.Info("finished reading sinker Activity events")
-	ctx.Done()
+	s.logger.Info("finished reading sinker_activity events")
 }

--- a/maestro/service/deploy_service.go
+++ b/maestro/service/deploy_service.go
@@ -2,12 +2,13 @@ package service
 
 import (
 	"context"
+	"time"
+
 	"github.com/orb-community/orb/maestro/deployment"
 	"github.com/orb-community/orb/maestro/kubecontrol"
 	maestroredis "github.com/orb-community/orb/maestro/redis"
 	"github.com/orb-community/orb/pkg/errors"
 	"go.uber.org/zap"
-	"time"
 )
 
 // EventService will hold the business logic of the handling events from both Listeners
@@ -107,12 +108,12 @@ func (d *eventService) HandleSinkActivity(ctx context.Context, event maestroredi
 			zap.String("status", event.State))
 		return errors.New("trying to deploy sink that is not active")
 	}
-	d.logger.Debug("handling sink activity event", zap.String("sink-id", event.SinkID))
 	deploymentEntry, _, err := d.deploymentService.GetDeployment(ctx, event.OwnerID, event.SinkID)
 	if err != nil {
 		d.logger.Warn("did not find collector entry for sink", zap.String("sink-id", event.SinkID))
 		return err
 	}
+	d.logger.Debug("handling sink activity event", zap.String("sink-id", event.SinkID), zap.String("deployment-status",deploymentEntry.LastStatus))
 	if deploymentEntry.LastStatus == "unknown" || deploymentEntry.LastStatus == "idle" {
 		// async update sink status to provisioning
 		go func() {

--- a/maestro/service/deploy_service.go
+++ b/maestro/service/deploy_service.go
@@ -150,7 +150,8 @@ func (d *eventService) HandleSinkIdle(ctx context.Context, event maestroredis.Si
 			d.logger.Error("error updating status to idle", zap.Error(err))
 		}
 	}()
-	_, err := d.deploymentService.NotifyCollector(ctx, event.OwnerID, event.SinkID, "deploy", "", "")
+	// dropping idle otel collector
+	_, err := d.deploymentService.NotifyCollector(ctx, event.OwnerID, event.SinkID, "delete", "", "")
 	if err != nil {
 		d.logger.Error("error trying to notify collector", zap.Error(err))
 		err2 := d.deploymentService.UpdateStatus(ctx, event.OwnerID, event.SinkID, "provisioning_error", err.Error())


### PR DESCRIPTION
This PR changes:
- fixed updatedeployment function, was always getting old configuration
- fixed killotelcollector was only deleting deployment, not configmap and service
- fixed sinker activity stream subscribe and event consuption
- fixed sinker idle stream subscribe and event consuption
- fixed delete otel collector when sinks be idle