### PR TITLE
feat(agent): allow otel to have multiples policies, but disable telemetry in each otel-backend policy running.

### DIFF
--- a/agent/backend/otel/exporter_builder.go
+++ b/agent/backend/otel/exporter_builder.go
@@ -34,8 +34,8 @@ type service struct {
 }
 
 type telemetry struct {
-	Metrics *metrics `yaml:"metrics"`
-	Enabled bool     `yaml:"enabled"`
+	Metrics *metrics `yaml:"metrics,omitempty"`
+	Enable  bool     `yaml:"enable"`
 }
 
 type metrics struct {
@@ -102,7 +102,7 @@ func (e *exporterBuilder) MergeDefaultValueWithPolicy(config openTelemetryConfig
 		config.Extensions = make(map[string]interface{})
 	}
 	tel := &telemetry{
-		Enabled: false,
+		Enable: false,
 	}
 	config.Service.Telemetry = tel
 	// Override metrics exporter and append attributes/policy_data processor

--- a/agent/backend/otel/exporter_builder.go
+++ b/agent/backend/otel/exporter_builder.go
@@ -35,11 +35,20 @@ type service struct {
 
 type telemetry struct {
 	Metrics *metrics `yaml:"metrics,omitempty"`
-	Enable  bool     `yaml:"enable"`
+	Logs    *logs    `yaml:"logs,omitempty"`
+	Traces  *traces  `yaml:"traces,omitempty"`
 }
 
 type metrics struct {
-	Address string `yaml:"address"`
+	Enable bool `yaml:"enable"`
+}
+
+type traces struct {
+	Enable bool `yaml:"enable"`
+}
+
+type logs struct {
+	Enable bool `yaml:"enable"`
 }
 
 type pipelines struct {
@@ -102,7 +111,7 @@ func (e *exporterBuilder) MergeDefaultValueWithPolicy(config openTelemetryConfig
 		config.Extensions = make(map[string]interface{})
 	}
 	tel := &telemetry{
-		Enable: false,
+		Metrics: &metrics{Enable: false},
 	}
 	config.Service.Telemetry = tel
 	// Override metrics exporter and append attributes/policy_data processor

--- a/agent/backend/otel/exporter_builder.go
+++ b/agent/backend/otel/exporter_builder.go
@@ -35,6 +35,7 @@ type service struct {
 
 type telemetry struct {
 	Metrics *metrics `yaml:"metrics"`
+	Enabled bool     `yaml:"enabled"`
 }
 
 type metrics struct {
@@ -72,7 +73,7 @@ func (e *exporterBuilder) GetStructFromYaml(yamlString string) (openTelemetryCon
 	return config, nil
 }
 
-func (e *exporterBuilder) MergeDefaultValueWithPolicy(config openTelemetryConfig, policyId string, policyName string, telemetryPort int) (openTelemetryConfig, error) {
+func (e *exporterBuilder) MergeDefaultValueWithPolicy(config openTelemetryConfig, policyId string, policyName string) (openTelemetryConfig, error) {
 	endpoint := e.host + ":" + strconv.Itoa(e.port)
 	defaultOtlpExporter := defaultOtlpExporter{
 		Endpoint: endpoint,
@@ -101,7 +102,7 @@ func (e *exporterBuilder) MergeDefaultValueWithPolicy(config openTelemetryConfig
 		config.Extensions = make(map[string]interface{})
 	}
 	tel := &telemetry{
-		Metrics: &metrics{Address: "0.0.0.0:" + strconv.Itoa(telemetryPort)},
+		Enabled: false,
 	}
 	config.Service.Telemetry = tel
 	// Override metrics exporter and append attributes/policy_data processor
@@ -135,8 +136,7 @@ func (o *openTelemetryBackend) buildDefaultExporterAndProcessor(policyYaml strin
 	defaultPolicyStruct, err = builder.MergeDefaultValueWithPolicy(
 		defaultPolicyStruct,
 		policyId,
-		policyName,
-		telemetryPort)
+		policyName)
 	if err != nil {
 		return openTelemetryConfig{}, err
 	}

--- a/agent/backend/otel/exporter_builder.go
+++ b/agent/backend/otel/exporter_builder.go
@@ -40,7 +40,8 @@ type telemetry struct {
 }
 
 type metrics struct {
-	Enabled bool `yaml:"enabled"`
+	Level   string `yaml:"level,omitempty"`
+	Address string `yaml:"address,omitempty"`
 }
 
 type traces struct {
@@ -111,7 +112,7 @@ func (e *exporterBuilder) MergeDefaultValueWithPolicy(config openTelemetryConfig
 		config.Extensions = make(map[string]interface{})
 	}
 	tel := &telemetry{
-		Metrics: &metrics{Enabled: false},
+		Metrics: &metrics{Level: "none"},
 	}
 	config.Service.Telemetry = tel
 	// Override metrics exporter and append attributes/policy_data processor

--- a/agent/backend/otel/exporter_builder.go
+++ b/agent/backend/otel/exporter_builder.go
@@ -40,15 +40,15 @@ type telemetry struct {
 }
 
 type metrics struct {
-	Enable bool `yaml:"enable"`
+	Enabled bool `yaml:"enabled"`
 }
 
 type traces struct {
-	Enable bool `yaml:"enable"`
+	Enabled bool `yaml:"enabled"`
 }
 
 type logs struct {
-	Enable bool `yaml:"enable"`
+	Enabled bool `yaml:"enabled"`
 }
 
 type pipelines struct {
@@ -111,7 +111,7 @@ func (e *exporterBuilder) MergeDefaultValueWithPolicy(config openTelemetryConfig
 		config.Extensions = make(map[string]interface{})
 	}
 	tel := &telemetry{
-		Metrics: &metrics{Enable: false},
+		Metrics: &metrics{Enabled: false},
 	}
 	config.Service.Telemetry = tel
 	// Override metrics exporter and append attributes/policy_data processor

--- a/agent/backend/otel/exporter_builder_test.go
+++ b/agent/backend/otel/exporter_builder_test.go
@@ -55,7 +55,7 @@ service:
 			if err != nil {
 				t.Errorf("failed to merge default value with policy: %v", err)
 			}
-			expectedStruct, err := exporterBuilder.MergeDefaultValueWithPolicy(gotOtelConfig, testCase.policyId, testCase.policyName, 8888)
+			expectedStruct, err := exporterBuilder.MergeDefaultValueWithPolicy(gotOtelConfig, testCase.policyId, testCase.policyName)
 			if err != nil {
 				t.Errorf("failed to merge default value with policy: %v", err)
 			}

--- a/agent/backend/otel/policy.go
+++ b/agent/backend/otel/policy.go
@@ -68,7 +68,7 @@ func (o *openTelemetryBackend) ApplyPolicy(newPolicyData policies.PolicyData, up
 			o.logger.Info("new policy version received, updating",
 				zap.String("policy_id", newPolicyData.ID),
 				zap.Int32("version", newPolicyData.Version))
-			if err := os.WriteFile(currentPolicyPath, []byte(policyYaml), os.ModeTemporary); err != nil {
+			if err := os.WriteFile(currentPolicyPath, policyYaml, os.ModeTemporary); err != nil {
 				return err
 			}
 			if err = o.policyRepo.Update(newPolicyData); err != nil {

--- a/agent/backend/otel/policy.go
+++ b/agent/backend/otel/policy.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 	"os"
+	"strings"
 )
 
 const tempFileNamePattern = "otel-%s-config.yml"
@@ -153,7 +154,7 @@ func (o *openTelemetryBackend) RemovePolicy(data policies.PolicyData) error {
 			return err
 		}
 		policyPath := o.policyConfigDirectory + fmt.Sprintf(tempFileNamePattern, data.ID)
-		if err := os.Remove(policyPath); err != nil && err != os.ErrNotExist {
+		if err := os.Remove(policyPath); err != nil && strings.Contains(err.Error(), "no such file or directory") {
 			o.logger.Error("error removing temporary file with policy", zap.Error(err))
 			return err
 		}

--- a/agent/backend/otel/policy.go
+++ b/agent/backend/otel/policy.go
@@ -36,14 +36,7 @@ func (o *openTelemetryBackend) ApplyPolicy(newPolicyData policies.PolicyData, up
 	if err = o.ValidatePolicy(otelConfig); err != nil {
 		return err
 	}
-	// Find unused port
-	port := 8889
-	for _, policy := range o.runningCollectors {
-		if policy.telemetryPort == port {
-			port++
-		}
-	}
-	otelConfig, err = builder.MergeDefaultValueWithPolicy(otelConfig, newPolicyData.ID, newPolicyData.Name, port)
+	otelConfig, err = builder.MergeDefaultValueWithPolicy(otelConfig, newPolicyData.ID, newPolicyData.Name)
 	if err != nil {
 		return err
 	}

--- a/agent/backend/otel/policy.go
+++ b/agent/backend/otel/policy.go
@@ -50,7 +50,7 @@ func (o *openTelemetryBackend) ApplyPolicy(newPolicyData policies.PolicyData, up
 			o.logger.Error("failed to create temporary file", zap.Error(err), zap.String("policy_id", newPolicyData.ID))
 			return err
 		}
-		o.logger.Debug("writing policy to temporary file", zap.String("policy_id", newPolicyData.ID), zap.String("policyData", string(policyYaml)))
+		o.logger.Debug("writing policy to temporary file", zap.String("policy_id", newPolicyData.ID), zap.String("policyData", string(newPolicyYaml)))
 		if _, err = temporaryFile.Write(newPolicyYaml); err != nil {
 			o.logger.Error("failed to write temporary file", zap.Error(err), zap.String("policy_id", newPolicyData.ID))
 			return err

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -34,10 +34,10 @@ func (a *agentLoggerWarn) Printf(format string, v ...interface{}) {
 	a.a.logger.Warn("WARN mqtt log", zap.Any("payload", v))
 }
 func (a *agentLoggerDebug) Println(v ...interface{}) {
-	a.a.logger.Debug("DEBUG mqtt log", zap.Any("payload", v))
+	//a.a.logger.Debug("DEBUG mqtt log", zap.Any("payload", v))
 }
 func (a *agentLoggerDebug) Printf(format string, v ...interface{}) {
-	a.a.logger.Debug("DEBUG mqtt log", zap.Any("payload", v))
+	//a.a.logger.Debug("DEBUG mqtt log", zap.Any("payload", v))
 }
 func (a *agentLoggerCritical) Println(v ...interface{}) {
 	a.a.logger.Error("CRITICAL mqtt log", zap.Any("payload", v))

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -34,10 +34,10 @@ func (a *agentLoggerWarn) Printf(format string, v ...interface{}) {
 	a.a.logger.Warn("WARN mqtt log", zap.Any("payload", v))
 }
 func (a *agentLoggerDebug) Println(v ...interface{}) {
-	//a.a.logger.Debug("DEBUG mqtt log", zap.Any("payload", v))
+	a.a.logger.Debug("DEBUG mqtt log", zap.Any("payload", v))
 }
 func (a *agentLoggerDebug) Printf(format string, v ...interface{}) {
-	//a.a.logger.Debug("DEBUG mqtt log", zap.Any("payload", v))
+	a.a.logger.Debug("DEBUG mqtt log", zap.Any("payload", v))
 }
 func (a *agentLoggerCritical) Println(v ...interface{}) {
 	a.a.logger.Error("CRITICAL mqtt log", zap.Any("payload", v))


### PR DESCRIPTION
Multiple policies running 
```
{"level":"debug","ts":"2023-11-21T17:27:56.130Z","caller":"agent/heartbeats.go:31","msg":"heartbeat"}
{"level":"debug","ts":"2023-11-21T17:28:29.211Z","caller":"otlpmqttexporter/otlp.go:171","msg":"scraped metrics for policy","policy":"github_check","policy_id":"cc7b31a2-8e57-4f1c-9504-7ef98b9f660b"}
{"level":"debug","ts":"2023-11-21T17:28:29.313Z","caller":"otlpmqttexporter/otlp.go:171","msg":"scraped metrics for policy","policy":"otel_orb_std","policy_id":"8f425ce7-2ac9-4f99-b3bd-7e2c1fafd389"}
{"level":"info","ts":"2023-11-21T17:28:29.427Z","caller":"otlpmqttexporter/otlp.go:305","msg":"scraped and published telemetry","topic":"channels/10b85acb-5635-420d-b5d1-c718727e1c8f/messages/otlp/otel/m/5","payload_size_b":1411,"compressed_payload_size_b":412}
{"level":"info","ts":"2023-11-21T17:28:29.526Z","caller":"otlpmqttexporter/otlp.go:305","msg":"scraped and published telemetry","topic":"channels/10b85acb-5635-420d-b5d1-c718727e1c8f/messages/otlp/otel/m/5","payload_size_b":2470,"compressed_payload_size_b":476}
{"level":"debug","ts":"2023-11-21T17:28:46.130Z","caller":"agent/heartbeats.go:31","msg":"heartbeat"}
```

![image](https://github.com/orb-community/orb/assets/6593889/abfdb38b-7016-4a6d-beef-5397e3b4a6cb)
