### PR TITLE
fix(agent): fixing port overriding if not set unless always setting.

### DIFF
--- a/agent/backend/otel/vars.go
+++ b/agent/backend/otel/vars.go
@@ -1,0 +1,7 @@
+package otel
+
+import "github.com/spf13/viper"
+
+func RegisterBackendSpecificVariables(viper *viper.Viper) {
+	viper.SetDefault("orb.backends.otel.otlp_port", "4316")
+}

--- a/agent/backend/pktvisor/vars.go
+++ b/agent/backend/pktvisor/vars.go
@@ -1,0 +1,12 @@
+package pktvisor
+
+import (
+	"github.com/spf13/viper"
+)
+
+func RegisterBackendSpecificVariables(viper *viper.Viper) {
+	viper.SetDefault("orb.backends.pktvisor.binary", "/usr/local/sbin/pktvisord")
+	viper.SetDefault("orb.backends.pktvisor.config_file", "/opt/orb/agent.yaml")
+	viper.SetDefault("orb.backends.pktvisor.api_host", "localhost")
+	viper.SetDefault("orb.backends.pktvisor.api_port", "10853")
+}

--- a/agent/otel/otlpmqttexporter/otlp.go
+++ b/agent/otel/otlpmqttexporter/otlp.go
@@ -168,7 +168,7 @@ func (e *baseExporter) pushMetrics(ctx context.Context, md pmetric.Metrics) erro
 		scope.Scope().Attributes().PutStr("policy_id", agentData.PolicyID)
 		scope.Scope().Attributes().PutStr("dataset_ids", datasets)
 		scope.CopyTo(ref.ScopeMetrics().AppendEmpty())
-		e.logger.Debug("scraped metrics for policy", zap.String("policy", policyNameStr), zap.String("policy_id", agentData.PolicyID))
+		e.logger.Info("scraped metrics for policy", zap.String("policy", policyNameStr), zap.String("policy_id", agentData.PolicyID))
 	}
 
 	request, err := tr.MarshalProto()

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -85,7 +85,9 @@ func Run(_ *cobra.Command, _ []string) {
 		configData.OrbAgent.Backends["pktvisor"] = make(map[string]string)
 		configData.OrbAgent.Backends["pktvisor"]["binary"] = pktvisor.DefaultBinary
 		configData.OrbAgent.Backends["pktvisor"]["api_host"] = "localhost"
-		configData.OrbAgent.Backends["pktvisor"]["api_port"] = "10853"
+		if _, ok := configData.OrbAgent.Backends["pktvisor"]["api_port"]; !ok {
+			configData.OrbAgent.Backends["pktvisor"]["api_port"] = "10853"
+		}
 		if len(cfgFiles) > 0 {
 			configData.OrbAgent.Backends["pktvisor"]["config_file"] = cfgFiles[0]
 		}

--- a/python-test/features/integration.feature
+++ b/python-test/features/integration.feature
@@ -902,7 +902,7 @@ Scenario: Remotely restart agents without policies applied
         And the container logs that were output after reset the agent contain the message "pktvisor process stopped" within 30 seconds
         And the container logs that were output after reset the agent contain the message "all backends and comms were restarted" within 30 seconds
         And 2 simple policies are applied to the group
-    Then the container logs should contain the message "restarting all backends" within 30 seconds
+    Then the container logs should contain the message "all backends and comms were restarted" within 30 seconds
         And this agent's heartbeat shows that 2 policies are applied and all has status running
         And the container logs that were output after reset the agent contain the message "policy applied successfully" referred to each applied policy within 20 seconds
         And the container logs that were output after reset the agent contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds


### PR DESCRIPTION
Fixing the Integration tests scenarios.

![image](https://github.com/orb-community/orb/assets/6593889/02589bd0-e786-46e5-8bd5-baa93f688857)

Log entry with fixed parameters sent to pktvisor
```json
{
  "level":"info",
  "ts":"2023-11-22T17:32:56.584Z",
  "caller":"pktvisor/pktvisor.go:189",
  "msg":"pktvisor startup",
  "arguments" : 
    [
      "--admin-api",
      "-l","localhost",
      "-p","51875",
      "--config","/tmp/orb-agent-pktvisor-conf.595wkU",
      "--otel","--otel-host","localhost","--otel-port","36253",
      "--cp-custom","ded19d73-2d01-457a-8866-72ae3e5a7c5d"
    ]
}
```

