### PR TITLE
chore: downgrade labeler to v4

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -9,4 +9,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v4


### PR DESCRIPTION
https://github.com/actions/labeler/releases/tag/v5.0.0 introduced breaking changes to configuration file format requiring extensive work on `.github/labeler.yml`.