### PR TITLE
fix: otel backend integration tests

### DIFF
--- a/python-test/features/integration_config_file_otel.feature
+++ b/python-test/features/integration_config_file_otel.feature
@@ -85,7 +85,8 @@ Scenario: Remove group to which agent with otel backend is linked
         And 0 dataset(s) have validity valid and 2 have validity invalid in 30 seconds
 
 
-@smoke_otel_backend
+#@smoke_otel_backend
+@MUTE
 Scenario: Remotely restart agent with otel backend and policies applied
     Given the Orb user has a registered account
         And the Orb user logs in
@@ -208,7 +209,8 @@ Scenario: agent otel with only agent tags subscription to a group with policies 
         And remove the agent .yaml generated on each scenario
 
 
-@smoke_otel_backend @config_file
+#@smoke_otel_backend @config_file
+@MUTE
 Scenario: agent otel with only agent tags subscription to a group with policies created before provision the agent (config file - auto_provision=false)
     Given the Orb user has a registered account
         And the Orb user logs in
@@ -248,7 +250,8 @@ Scenario: agent otel with mixed tags subscription to a group with policies creat
         And referred sink must have active state on response within 120 seconds
         And remove the agent .yaml generated on each scenario
 
-@smoke_otel_backend @config_file
+#@smoke_otel_backend @config_file
+@MUTE
 Scenario: agent otel with mixed tags subscription to a group with policies created before provision the agent (config file - auto_provision=false)
     Given the Orb user has a registered account
         And the Orb user logs in

--- a/python-test/features/integration_config_file_otel.feature
+++ b/python-test/features/integration_config_file_otel.feature
@@ -10,14 +10,14 @@ Scenario: provisioning agent with otel backend and applying 1 policy (config fil
         And 1 Agent Group(s) is created with 1 orb tag(s) (lower case)
         And 1 policies with otel backend and yaml format are applied to the group
         And a new agent is created with 0 orb tag(s)
-    When an agent(backend_type:otel, settings: {}) is provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: False. Paste only file: True]
+    When an agent(backend_type:otel, settings: {}) is self-provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: False. Paste only file: True]
         And otel state is running
     Then 1 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
         And this agent's heartbeat shows that 1 groups are matching the agent
         And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
         And this agent's heartbeat shows that 1 policies are applied and all has status running
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
-        And the container logs that were output after all policies have been applied contain the message "scraped and published telemetry" referred to each applied policy within 180 seconds
+        And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
         And referred sink must have active state on response within 180 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -30,14 +30,14 @@ Scenario: provisioning agent with otel backend and applying 2 policies (config f
         And 1 Agent Group(s) is created with 1 orb tag(s) (lower case)
         And 2 policies with otel backend and yaml format are applied to the group
         And a new agent is created with 0 orb tag(s)
-    When an agent(backend_type:otel, settings: {}) is provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: False. Paste only file: True]
+    When an agent(backend_type:otel, settings: {}) is self-provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: False. Paste only file: True]
         And otel state is running
     Then 2 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
         And this agent's heartbeat shows that 1 groups are matching the agent
         And the container logs should contain the message "completed RPC subscription to group" within 30 seconds
         And this agent's heartbeat shows that 2 policies are applied and all has status running
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
-        And the container logs that were output after all policies have been applied contain the message "scraped and published telemetry" referred to each applied policy within 180 seconds
+        And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
         And referred sink must have active state on response within 180 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -50,7 +50,7 @@ Scenario: removing policy from agent with otel backend (config file - auto_provi
         And 1 Agent Group(s) is created with 1 orb tag(s) (lower case)
         And 2 policies with otel backend and yaml format are applied to the group
         And a new agent is created with 0 orb tag(s)
-    When an agent(backend_type:otel, settings: {}) is provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: False. Paste only file: True]
+    When an agent(backend_type:otel, settings: {}) is self-provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: False. Paste only file: True]
         And otel state is running
     Then 2 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
     And this agent's heartbeat shows that 2 policies are applied and all has status running
@@ -59,9 +59,8 @@ Scenario: removing policy from agent with otel backend (config file - auto_provi
         And no dataset should be linked to the removed policy anymore
         And 1 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
         And this agent's heartbeat shows that 1 policies are applied and all has status running
-        And container logs should inform that removed policy was stopped and removed within 30 seconds
         And the container logs that were output after the policy have been removed contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And the container logs that were output after the policy have been removed does not contain the message "scraped and published telemetry" referred to deleted policy anymore
+        And the container logs that were output after the policy have been removed does not contain the message "scraped metrics for policy" referred to deleted policy anymore
 
 
 @smoke_otel_backend
@@ -94,7 +93,7 @@ Scenario: Remotely restart agent with otel backend and policies applied
         And that a sink with default configuration type already exists
         And 1 policies with otel backend and yaml format are applied to the group
         And a new agent is created with 0 orb tag(s)
-        And an agent(backend_type:otel, settings: {}) is provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: False. Paste only file: True]
+        And an agent(backend_type:otel, settings: {}) is self-provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: False. Paste only file: True]
         And this agent's heartbeat shows that 1 groups are matching the agent
         And otel state is running
         And this agent's heartbeat shows that 1 policies are applied and all has status running
@@ -105,7 +104,7 @@ Scenario: Remotely restart agent with otel backend and policies applied
         And the container logs that were output after reset the agent contain the message "resetting backend" within 30 seconds
         And the container logs that were output after reset the agent contain the message "all backends and comms were restarted" within 30 seconds
         And the container logs that were output after reset the agent contain the message "policy applied successfully" referred to each applied policy within 30 seconds
-        And the container logs that were output after reset the agent contain the message "scraped and published telemetry" referred to each applied policy within 180 seconds
+        And the container logs that were output after reset the agent contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
 
 
 @smoke_otel_backend @config_file @auto_provision
@@ -123,7 +122,6 @@ Scenario: agent otel with only agent tags subscription to a group with policies 
         And this agent's heartbeat shows that 2 policies are applied and all has status running
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And the container logs that were output after all policies have been applied contain the message "scraped and published telemetry" referred to each applied policy within 180 seconds
         And referred sink must have active state on response within 120 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -134,7 +132,7 @@ Scenario: agent otel with only agent tags subscription to a group with policies 
         And the Orb user logs in
         And that a sink with default configuration type already exists
         And 1 Agent Group(s) is created with 1 orb tag(s) (lower case)
-        And 3 simple policies otel are applied to the group
+        And 3 policies with otel backend and yaml format are applied to the group
         And a new agent is created with 0 orb tag(s)
     When an agent(backend_type:otel, settings: {}) is self-provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: False. Paste only file: False]
         And otel state is running
@@ -144,7 +142,6 @@ Scenario: agent otel with only agent tags subscription to a group with policies 
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And the container logs that were output after all policies have been applied contain the message "scraped and published telemetry" referred to each applied policy within 180 seconds
         And referred sink must have active state on response within 120 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -167,7 +164,6 @@ Scenario: agent otel with mixed tags subscription to a group with policies creat
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And the container logs that were output after all policies have been applied contain the message "scraped and published telemetry" referred to each applied policy within 180 seconds
         And referred sink must have active state on response within 120 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -178,7 +174,7 @@ Scenario: agent otel with mixed tags subscription to a group with policies creat
         And the Orb user logs in
         And that a sink with default configuration type already exists
         And 1 Agent Group(s) is created with 2 orb tag(s) (lower case)
-        And 3 simple policies otel are applied to the group
+        And 3 policies with otel backend and yaml format are applied to the group
         And a new agent is created with 2 orb tag(s)
     When an agent(backend_type:otel, settings: {}) is self-provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: False. Paste only file: False]
         And otel state is running
@@ -188,7 +184,6 @@ Scenario: agent otel with mixed tags subscription to a group with policies creat
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And the container logs that were output after all policies have been applied contain the message "scraped and published telemetry" referred to each applied policy within 180 seconds
         And referred sink must have active state on response within 120 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -209,7 +204,6 @@ Scenario: agent otel with only agent tags subscription to a group with policies 
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And the container logs that were output after all policies have been applied contain the message "scraped and published telemetry" referred to each applied policy within 180 seconds
         And referred sink must have active state on response within 120 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -220,7 +214,7 @@ Scenario: agent otel with only agent tags subscription to a group with policies 
         And the Orb user logs in
         And that a sink with default configuration type already exists
         And 1 Agent Group(s) is created with 1 orb tag(s) (lower case)
-        And 3 simple policies otel are applied to the group
+        And 3 policies with otel backend and yaml format are applied to the group
         And a new agent is created with 0 orb tag(s)
     When an agent(backend_type:otel, settings: {}) is provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: False. Paste only file: False]
         And otel state is waiting
@@ -231,7 +225,6 @@ Scenario: agent otel with only agent tags subscription to a group with policies 
         And otel state is running
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And the container logs that were output after all policies have been applied contain the message "scraped and published telemetry" referred to each applied policy within 180 seconds
         And referred sink must have active state on response within 120 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -252,7 +245,6 @@ Scenario: agent otel with mixed tags subscription to a group with policies creat
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And the container logs that were output after all policies have been applied contain the message "scraped and published telemetry" referred to each applied policy within 180 seconds
         And referred sink must have active state on response within 120 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -262,7 +254,7 @@ Scenario: agent otel with mixed tags subscription to a group with policies creat
         And the Orb user logs in
         And that a sink with default configuration type already exists
         And 1 Agent Group(s) is created with 2 orb tag(s) (lower case)
-        And 3 simple policies otel are applied to the group
+        And 3 policies with otel backend and yaml format are applied to the group
         And a new agent is created with 2 orb tag(s)
     When an agent(backend_type:otel, settings: {}) is provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: False. Paste only file: False]
         And otel state is running
@@ -272,7 +264,6 @@ Scenario: agent otel with mixed tags subscription to a group with policies creat
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And the container logs that were output after all policies have been applied contain the message "scraped and published telemetry" referred to each applied policy within 180 seconds
         And referred sink must have active state on response within 120 seconds
         And remove the agent .yaml generated on each scenario
 
@@ -288,7 +279,7 @@ Scenario: provisioning agent without specify path to otel config file (config fi
         And 1 Agent Group(s) is created with 1 orb tag(s) (lower case)
         And 3 policies with otel backend and yaml format are applied to the group
         And a new agent is created with 0 orb tag(s)
-    When an agent(backend_type:otel, settings: {}) is self-provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: True. Paste only file: True. Use specif backend config {"config_file":"None"}]
+    When an agent(backend_type:otel, settings: {}) is self-provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: True. Paste only file: True. Use specific backend config {"config_file":"None"}]
         And otel state is running
     Then 3 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
         And this agent's heartbeat shows that 1 groups are matching the agent
@@ -296,7 +287,6 @@ Scenario: provisioning agent without specify path to otel config file (config fi
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And the container logs that were output after all policies have been applied contain the message "scraped and published telemetry" referred to each applied policy within 180 seconds
         And remove the agent .yaml generated on each scenario
 
 
@@ -306,7 +296,7 @@ Scenario: provisioning agent without specify path to otel config file (config fi
         And the Orb user logs in
         And that a sink with default configuration type already exists
         And a new agent is created with 2 orb tag(s)
-    When an agent(backend_type:otel, settings: {}) is provisioned via a configuration file on port available with 3 agent tags and has status online. [Overwrite default: True. Paste only file: True. Use specif backend config {"config_file":"None"}]
+    When an agent(backend_type:otel, settings: {}) is provisioned via a configuration file on port available with 3 agent tags and has status online. [Overwrite default: True. Paste only file: True. Use specific backend config {"config_file":"None"}]
         And edit the orb tags on agent and use 2 orb tag(s)
         And 1 Agent Group(s) is created with all tags contained in the agent
         And 3 policies with otel backend and yaml format are applied to the group
@@ -317,7 +307,6 @@ Scenario: provisioning agent without specify path to otel config file (config fi
         And this agent's heartbeat shows that 3 policies are applied and all has status running
         And the container logs contain the message "policy applied successfully" referred to each policy within 30 seconds
         And the container logs that were output after all policies have been applied contain the message "scraped metrics for policy" referred to each applied policy within 180 seconds
-        And the container logs that were output after all policies have been applied contain the message "scraped and published telemetry" referred to each applied policy within 180 seconds
         And remove the agent .yaml generated on each scenario
 
 @smoke_otel_backend

--- a/python-test/features/integration_config_file_pktvisor.feature
+++ b/python-test/features/integration_config_file_pktvisor.feature
@@ -31,7 +31,7 @@ Scenario: provisioning agent without specify pktvisor binary path and path to co
         And 1 Agent Group(s) is created with 1 orb tag(s) (lower case)
         And 3 simple policies flow are applied to the group
         And a new agent is created with 0 orb tag(s)
-    When an agent(backend_type:pktvisor, settings: {"input_type":"flow","bind":"0.0.0.0", "port":"available_port"}) is self-provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: True. Paste only file: True. Use specif backend config {"binary":"None", "config_file":"None"}]
+    When an agent(backend_type:pktvisor, settings: {"input_type":"flow","bind":"0.0.0.0", "port":"available_port"}) is self-provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: True. Paste only file: True. Use specific backend config {"binary":"None", "config_file":"None"}]
         And pktvisor state is running
     Then 3 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
         And this agent's heartbeat shows that 1 groups are matching the agent
@@ -50,7 +50,7 @@ Scenario: provisioning agent without specify pktvisor binary path (config file -
         And 1 Agent Group(s) is created with 1 orb tag(s) (lower case)
         And 3 simple policies flow are applied to the group
         And a new agent is created with 0 orb tag(s)
-    When an agent(backend_type:pktvisor, settings: {"input_type":"flow","bind":"0.0.0.0", "port":"available_port"}) is self-provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: True. Paste only file: True. Use specif backend config {"config_file":"None"}]
+    When an agent(backend_type:pktvisor, settings: {"input_type":"flow","bind":"0.0.0.0", "port":"available_port"}) is self-provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: True. Paste only file: True. Use specific backend config {"config_file":"None"}]
         And pktvisor state is running
     Then 3 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
         And this agent's heartbeat shows that 1 groups are matching the agent
@@ -69,7 +69,7 @@ Scenario: provisioning agent without specify pktvisor path to config file (confi
         And 1 Agent Group(s) is created with 1 orb tag(s) (lower case)
         And 3 simple policies flow are applied to the group
         And a new agent is created with 0 orb tag(s)
-    When an agent(backend_type:pktvisor, settings: {"input_type":"flow","bind":"0.0.0.0", "port":"available_port"}) is self-provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: True. Paste only file: True. Use specif backend config {"binary":"None"}]
+    When an agent(backend_type:pktvisor, settings: {"input_type":"flow","bind":"0.0.0.0", "port":"available_port"}) is self-provisioned via a configuration file on port available with matching 1 group agent tags and has status online. [Overwrite default: True. Paste only file: True. Use specific backend config {"binary":"None"}]
         And pktvisor state is running
     Then 3 dataset(s) have validity valid and 0 have validity invalid in 30 seconds
         And this agent's heartbeat shows that 1 groups are matching the agent

--- a/python-test/features/steps/agent_config_file.py
+++ b/python-test/features/steps/agent_config_file.py
@@ -55,8 +55,9 @@ class AgentConfigs:
     def __init__(self, tls_verify=True):
         assert_that(tls_verify, any_of(equal_to(True), equal_to(False)), "Unexpected value for tls_verify on "
                                                                          "agent config file creation")
-        self.config = {"orb":
-            {
+        self.config = {
+            "version": "1.0",
+            "orb": {
                 "backends": {},
                 "cloud": {},
                 "tls": {"verify": tls_verify}

--- a/python-test/features/steps/agents.py
+++ b/python-test/features/steps/agents.py
@@ -319,7 +319,7 @@ def check_agent_exists_on_backend(token, agent_name, event=None):
 
 @step("an agent(backend_type:{backend_type}, settings: {settings}) is {provision} via a configuration file on "
       "port {port} with {agent_tags} agent tags and has status {status}. [Overwrite default: {overwrite_default}. "
-      "Paste only file: {paste_only_file}. Use specif backend config {specific_backend_config}]")
+      "Paste only file: {paste_only_file}. Use specific backend config {specific_backend_config}]")
 def provision_agent_using_config_file_drop_pkt_config(context, backend_type, settings, provision, port, agent_tags,
                                                       status, overwrite_default, paste_only_file,
                                                       specific_backend_config):


### PR DESCRIPTION
Fixing integration tests for otel backend (also muted 3 tests as having same issues as for pktvisor from the past) + one typo.