### PR TITLE
fix(sinks): ciphered data on sink.update redis event

### DIFF
--- a/sinks/api/http/endpoint.go
+++ b/sinks/api/http/endpoint.go
@@ -129,11 +129,19 @@ func updateSinkEndpoint(svc sinks.SinkService) endpoint.Endpoint {
 		if req.token == "" {
 			return nil, errors.ErrUnauthorizedAccess
 		}
+		// TODO this needs to be refactored the logics are duplicated in both endpoint and service
 		currentSink, err := svc.ViewSink(ctx, req.token, req.id)
 		if err != nil {
 			svc.GetLogger().Error("could not find sink with id", zap.String("sinkID", req.id), zap.Error(err))
 			return nil, err
 		}
+		// TODO not the best solution for now, but it works
+		currentSink, err = svc.ViewSinkInternal(ctx, currentSink.MFOwnerID, req.id)
+		if err != nil {
+			svc.GetLogger().Error("could not find sink with id", zap.String("sinkID", req.id), zap.Error(err))
+			return nil, err
+		}
+
 		if err := req.validate(); err != nil {
 			svc.GetLogger().Error("error validating request", zap.Error(err))
 			return nil, err

--- a/sinks/mocks/sinks.go
+++ b/sinks/mocks/sinks.go
@@ -165,9 +165,7 @@ func (s *sinkRepositoryMock) RetrieveById(ctx context.Context, key string) (sink
 	if c, ok := s.sinksMock.Get(key); ok {
 		// Pass test schema
 		v := c.Config.GetSubMetadata(authentication_type.AuthenticationKey)
-		if v["password"] == "dbpass" {
-			v["password"], _ = s.passSvc.EncodePassword(v["password"].(string))
-		}
+		v["password"], _ = s.passSvc.EncodePassword(v["password"].(string))
 		return c, nil
 	}
 

--- a/sinks/mocks/sinks.go
+++ b/sinks/mocks/sinks.go
@@ -165,7 +165,9 @@ func (s *sinkRepositoryMock) RetrieveById(ctx context.Context, key string) (sink
 	if c, ok := s.sinksMock.Get(key); ok {
 		// Pass test schema
 		v := c.Config.GetSubMetadata(authentication_type.AuthenticationKey)
-		v["password"], _ = s.passSvc.EncodePassword(v["password"].(string))
+		if v["password"] == "dbpass" || v["password"] == "w0w-orb-Rocks!" || v["password"] == "newpass" {
+			v["password"], _ = s.passSvc.EncodePassword(v["password"].(string))
+		}
 		return c, nil
 	}
 

--- a/sinks/sinks_service.go
+++ b/sinks/sinks_service.go
@@ -279,8 +279,10 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 	var cfg Configuration
 	if sink.Config == nil && sink.ConfigData == "" {
 		// No config sent, keep the previous
-		sink.Config = currentSink.Config
-		if currentSink.ConfigData != "" {
+		if currentSink.Config == nil {
+			sink.Config = currentSink.Config
+		}
+		if currentSink.ConfigData == "" {
 			sink.ConfigData = currentSink.ConfigData
 		}
 		authType, _ := authentication_type.GetAuthType(sink.GetAuthenticationTypeName())

--- a/sinks/sinks_service.go
+++ b/sinks/sinks_service.go
@@ -280,6 +280,9 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 	if sink.Config == nil && sink.ConfigData == "" {
 		// No config sent, keep the previous
 		sink.Config = currentSink.Config
+		if currentSink.ConfigData != "" {
+			sink.ConfigData = currentSink.ConfigData
+		}
 		authType, _ := authentication_type.GetAuthType(sink.GetAuthenticationTypeName())
 		be := backend.GetBackend(currentSink.Backend)
 		cfg = Configuration{
@@ -288,7 +291,7 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 		}
 
 		// get the decrypted config, otherwise the password would be encrypted again
-		sink, err = svc.decryptMetadata(cfg, sink)
+		sink, err = svc.decryptMetadata(cfg, currentSink)
 		if err != nil {
 			return Sink{}, errors.Wrap(ErrUpdateEntity, err)
 		}

--- a/sinks/sinks_service.go
+++ b/sinks/sinks_service.go
@@ -277,11 +277,14 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 		return Sink{}, err
 	}
 	var cfg Configuration
+	svc.logger.Info("DEBUG config", zap.Any("config", sink.Config),
+		zap.Any("configData", sink.ConfigData))
 	if sink.Config == nil && sink.ConfigData == "" {
 		// No config sent, keep the previous
 		sink.Config = currentSink.Config
 		sink.ConfigData = currentSink.ConfigData
-
+		svc.logger.Info("DEBUG config", zap.Any("config", sink.Config),
+			zap.Any("configData", sink.ConfigData))
 		authType, _ := authentication_type.GetAuthType(sink.GetAuthenticationTypeName())
 		be := backend.GetBackend(currentSink.Backend)
 		cfg = Configuration{

--- a/sinks/sinks_service.go
+++ b/sinks/sinks_service.go
@@ -279,12 +279,9 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 	var cfg Configuration
 	if sink.Config == nil && sink.ConfigData == "" {
 		// No config sent, keep the previous
-		if currentSink.Config == nil {
-			sink.Config = currentSink.Config
-		}
-		if currentSink.ConfigData == "" {
-			sink.ConfigData = currentSink.ConfigData
-		}
+		sink.Config = currentSink.Config
+		sink.ConfigData = currentSink.ConfigData
+
 		authType, _ := authentication_type.GetAuthType(sink.GetAuthenticationTypeName())
 		be := backend.GetBackend(currentSink.Backend)
 		cfg = Configuration{
@@ -293,7 +290,7 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 		}
 
 		// get the decrypted config, otherwise the password would be encrypted again
-		sink, err = svc.decryptMetadata(cfg, currentSink)
+		sink, err = svc.decryptMetadata(cfg, sink)
 		if err != nil {
 			return Sink{}, errors.Wrap(ErrUpdateEntity, err)
 		}

--- a/sinks/sinks_service.go
+++ b/sinks/sinks_service.go
@@ -277,14 +277,10 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 		return Sink{}, err
 	}
 	var cfg Configuration
-	svc.logger.Info("DEBUG config", zap.Any("config", sink.Config),
-		zap.Any("configData", sink.ConfigData))
 	if sink.Config == nil && sink.ConfigData == "" {
 		// No config sent, keep the previous
 		sink.Config = currentSink.Config
 		sink.ConfigData = currentSink.ConfigData
-		svc.logger.Info("DEBUG config", zap.Any("config", sink.Config),
-			zap.Any("configData", sink.ConfigData))
 		authType, _ := authentication_type.GetAuthType(sink.GetAuthenticationTypeName())
 		be := backend.GetBackend(currentSink.Backend)
 		cfg = Configuration{

--- a/sinks/sinks_service_test.go
+++ b/sinks/sinks_service_test.go
@@ -209,6 +209,7 @@ func TestPartialUpdateSink(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("unexpected error: %s", err))
 	//aNewDescription := "A new description worthy reading"
 	aInitialDescription := "A initial description worthy reading"
+	aNewDescription := "new description"
 	initialJsonSink := sinks.Sink{
 		Name:        jsonSinkName,
 		Description: &aInitialDescription,
@@ -267,6 +268,15 @@ func TestPartialUpdateSink(t *testing.T) {
 			expected: func(t *testing.T, value sinks.Sink, err error) {
 				require.NoError(t, err, "no error expected")
 				require.Equalf(t, "https://orb.community/", value.Config.GetSubMetadata("exporter")["remote_host"], "want %s, got %s", "https://orb.community/", value.Config.GetSubMetadata("exporter")["remote_host"])
+			},
+			token: token,
+		}, "update description": {
+			requestSink: sinks.Sink{
+				ID:          yamlCreatedSink.ID,
+				Description: &aNewDescription,
+			},
+			expected: func(t *testing.T, value sinks.Sink, err error) {
+				require.NoError(t, err, "no error expected")
 			},
 			token: token,
 		},


### PR DESCRIPTION
This fixes the sink.update event going sometimes with the ciphered data for password.

![image](https://github.com/orb-community/orb/assets/6593889/1ffe12cd-da82-45d5-a7c2-5d1ce690411d)
