### PR TITLE
fix(sinks): prevent circular config metadata encryption

### DIFF
--- a/sinks/mocks/sinks.go
+++ b/sinks/mocks/sinks.go
@@ -30,23 +30,23 @@ type sinkRepositoryMock struct {
 	sinksMock immutable.Map[string, sinks.Sink]
 }
 
-func (s *sinkRepositoryMock) GetVersion(ctx context.Context) (string, error) {
+func (s *sinkRepositoryMock) GetVersion(_ context.Context) (string, error) {
 	return "", nil
 }
 
-func (s *sinkRepositoryMock) UpdateVersion(ctx context.Context, version string) error {
+func (s *sinkRepositoryMock) UpdateVersion(_ context.Context, _ string) error {
 	return nil
 }
 
-func (s *sinkRepositoryMock) SearchAllSinks(ctx context.Context, filter sinks.Filter) ([]sinks.Sink, error) {
+func (s *sinkRepositoryMock) SearchAllSinks(_ context.Context, _ sinks.Filter) ([]sinks.Sink, error) {
 	return nil, nil
 }
 
-func (s *sinkRepositoryMock) UpdateSinkState(ctx context.Context, sinkID string, msg string, ownerID string, state sinks.State) error {
+func (s *sinkRepositoryMock) UpdateSinkState(_ context.Context, _ string, _ string, _ string, _ sinks.State) error {
 	return nil
 }
 
-func (s *sinkRepositoryMock) RetrieveByOwnerAndId(ctx context.Context, ownerID string, key string) (sinks.Sink, error) {
+func (s *sinkRepositoryMock) RetrieveByOwnerAndId(_ context.Context, ownerID string, key string) (sinks.Sink, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -54,7 +54,7 @@ func (s *sinkRepositoryMock) RetrieveByOwnerAndId(ctx context.Context, ownerID s
 		if sink.MFOwnerID == ownerID {
 			// pass test code
 			v := sink.Config.GetSubMetadata(authentication_type.AuthenticationKey)
-			if v["password"] == "dbpass" {
+			if v["password"] == "dbpass" || v["password"] == "newpass" {
 				v["password"], _ = s.passSvc.EncodePassword(v["password"].(string))
 			}
 			return sink, nil
@@ -74,7 +74,7 @@ func NewSinkRepository(passSvc authentication_type.PasswordService) sinks.SinkRe
 	}
 }
 
-func (s *sinkRepositoryMock) Save(ctx context.Context, sink sinks.Sink) (string, error) {
+func (s *sinkRepositoryMock) Save(_ context.Context, sink sinks.Sink) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -98,7 +98,7 @@ func (s *sinkRepositoryMock) Save(ctx context.Context, sink sinks.Sink) (string,
 	return sink.ID, nil
 }
 
-func (s *sinkRepositoryMock) Update(ctx context.Context, sink sinks.Sink) (err error) {
+func (s *sinkRepositoryMock) Update(_ context.Context, sink sinks.Sink) (err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if c, ok := s.sinksMock.Get(sink.ID); ok {
@@ -124,7 +124,7 @@ func copyMetadata(dst, src types.Metadata) {
 	}
 }
 
-func (s *sinkRepositoryMock) RetrieveAllByOwnerID(ctx context.Context, owner string, pm sinks.PageMetadata) (sinks.Page, error) {
+func (s *sinkRepositoryMock) RetrieveAllByOwnerID(_ context.Context, owner string, pm sinks.PageMetadata) (sinks.Page, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -158,14 +158,14 @@ func (s *sinkRepositoryMock) RetrieveAllByOwnerID(ctx context.Context, owner str
 	return page, nil
 }
 
-func (s *sinkRepositoryMock) RetrieveById(ctx context.Context, key string) (sinks.Sink, error) {
+func (s *sinkRepositoryMock) RetrieveById(_ context.Context, key string) (sinks.Sink, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if c, ok := s.sinksMock.Get(key); ok {
 		// Pass test schema
 		v := c.Config.GetSubMetadata(authentication_type.AuthenticationKey)
-		if v["password"] == "dbpass" {
+		if v["password"] == "dbpass" || v["password"] == "newpass" {
 			v["password"], _ = s.passSvc.EncodePassword(v["password"].(string))
 		}
 		return c, nil
@@ -174,7 +174,7 @@ func (s *sinkRepositoryMock) RetrieveById(ctx context.Context, key string) (sink
 	return sinks.Sink{}, sinks.ErrNotFound
 }
 
-func (s *sinkRepositoryMock) Remove(ctx context.Context, owner string, key string) error {
+func (s *sinkRepositoryMock) Remove(_ context.Context, owner string, key string) error {
 	if c, ok := s.sinksMock.Get(key); ok {
 		if c.MFOwnerID == owner {
 			s.sinksMock = *s.sinksMock.Delete(key)

--- a/sinks/sinks_service.go
+++ b/sinks/sinks_service.go
@@ -54,7 +54,7 @@ func (svc sinkService) CreateSink(ctx context.Context, token string, sink Sink) 
 		return Sink{}, err
 	}
 
-	//// add default values
+	// add default values
 	defaultMetadata := make(types.Metadata, 1)
 	defaultMetadata["opentelemetry"] = "enabled"
 	sink.Config.Merge(defaultMetadata)
@@ -271,27 +271,28 @@ func (svc sinkService) UpdateSink(ctx context.Context, token string, sink Sink) 
 		return Sink{}, err
 	}
 
-	var currentSink Sink
-	currentSink, err = svc.sinkRepo.RetrieveById(ctx, sink.ID)
+	currentSink, err := svc.sinkRepo.RetrieveById(ctx, sink.ID)
 	if err != nil {
 		return Sink{}, err
 	}
-	var cfg Configuration
+
+	authType, _ := authentication_type.GetAuthType(sink.GetAuthenticationTypeName())
+	be := backend.GetBackend(currentSink.Backend)
+	cfg := Configuration{
+		Authentication: authType,
+		Exporter:       be,
+	}
+
+	// get the decrypted config, otherwise the password would be encrypted again
+	currentSink, err = svc.decryptMetadata(cfg, currentSink)
+	if err != nil {
+		return Sink{}, errors.Wrap(ErrUpdateEntity, err)
+	}
+
 	if sink.Config == nil && sink.ConfigData == "" {
 		// No config sent, keep the previous
 		sink.Config = currentSink.Config
-		authType, _ := authentication_type.GetAuthType(sink.GetAuthenticationTypeName())
-		be := backend.GetBackend(currentSink.Backend)
-		cfg = Configuration{
-			Authentication: authType,
-			Exporter:       be,
-		}
-
-		// get the decrypted config, otherwise the password would be encrypted again
-		sink, err = svc.decryptMetadata(cfg, sink)
-		if err != nil {
-			return Sink{}, errors.Wrap(ErrUpdateEntity, err)
-		}
+		sink.ConfigData = currentSink.ConfigData
 	} else {
 		sink.Backend = currentSink.Backend
 		be, err := svc.validateBackend(&sink)


### PR DESCRIPTION
We discovered an issue in the sinks service when user updates existing sink (i.e. name, description, tags) without config. In such scenario, encrypted password of the existing config metadata is being encrypted again. This leads to existing sink/otelcollectors not being able to authenticate with prometheus/otlphttp backends. 

For sinks already affected by this issue, the recommended solution is to update existing sinks with correct backend credentials.