### PR TITLE
feat(sinks): enable sinks with token auth.

### DIFF
--- a/maestro/config/types.go
+++ b/maestro/config/types.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"database/sql/driver"
-	"github.com/orb-community/orb/pkg/types"
 	"time"
+
+	"github.com/orb-community/orb/pkg/types"
 )
 
 type SinkData struct {
@@ -82,8 +83,8 @@ type Extensions struct {
 	PProf                *PProfExtension       `json:"pprof,omitempty" yaml:"pprof,omitempty" :"p_prof"`
 	ZPages               *ZPagesExtension      `json:"zpages,omitempty" yaml:"zpages,omitempty" :"z_pages"`
 	// Exporters Authentication
-	BasicAuth *BasicAuthenticationExtension `json:"basicauth/exporter,omitempty" yaml:"basicauth/exporter,omitempty" :"basic_auth"`
-	//BearerAuth *BearerAuthExtension          `json:"bearerauth/exporter,omitempty" yaml:"bearerauth/exporter,omitempty" :"bearer_auth"`
+	BasicAuth  *BasicAuthenticationExtension `json:"basicauth/exporter,omitempty" yaml:"basicauth/exporter,omitempty" :"basic_auth"`
+	BearerAuth *BearerTokenAuthExtension     `json:"bearertokenauth/withscheme,omitempty" yaml:"bearertokenauth/withscheme,omitempty"`
 }
 
 type HealthCheckExtension struct {
@@ -115,10 +116,9 @@ type BasicAuthenticationExtension struct {
 	ClientAuth *ClientAuth `json:"client_auth" yaml:"client_auth"`
 }
 
-type BearerAuthExtension struct {
-	BearerAuth *struct {
-		Token string `json:"token" yaml:"token"`
-	} `json:"client_auth" yaml:"client_auth"`
+type BearerTokenAuthExtension struct {
+	Scheme string `json:"scheme" yaml:"scheme"`
+	Token  string `json:"token" yaml:"token"`
 }
 
 type Exporters struct {

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -36,44 +36,44 @@ var (
 	// ErrExporterFieldNotFound indicates that exporter field was not found
 	ErrExporterFieldNotFound = New("malformed entity specification. exporter field is expected on configuration field")
 
-	// ErrAuthFieldNotFound indicates that authentication field was not found on configuration field
-	ErrAuthFieldNotFound = New("malformed entity specification. authentication fields are expected on configuration field")
-
-	// ErrAuthTypeNotFound indicates that authentication type field was not found on the authentication field
-	ErrAuthTypeNotFound = New("malformed entity specification: authentication type field is expected on configuration field")
-
-	// ErrInvalidAuthType indicates invalid authentication type
-	ErrInvalidAuthType = New("malformed entity specification. type key on authentication field is invalid")
-
-	// ErrUsernameNotFound indicates that username key was not found
-	ErrUsernameNotFound = New("malformed entity specification. username key is expected on authentication field")
-
-	// ErrPasswordNotFound indicates that password key was not found
-	ErrPasswordNotFound = New("malformed entity specification. password key is expected on authentication field")
-
-	// ErrSchemeNotFound indicates that scheme key was not found
-	ErrSchemeNotFound = New("malformed entity specification. scheme key is expected on authentication field")
-
-	// ErrTokendNotFound indicates that token key was not found
-	ErrTokenNotFound = New("malformed entity specification. token key is expected on authentication field")
-
 	// ErrEndPointNotFound indicates that endpoint field was not found on exporter field for otlp backend
 	ErrEndpointNotFound = New("malformed entity specification. endpoint field is expected on exporter field")
 
 	// ErrInvalidEndpoint indicates that endpoint field is not valid
 	ErrInvalidEndpoint = New("malformed entity specification. endpoint field is invalid")
 
-	// ErrInvalidPasswordType indicates invalid password key on authentication field
-	ErrInvalidPasswordType = New("malformed entity specification. password key on authentication field is invalid")
+	// ErrAuthFieldNotFound indicates that authentication field was not found on configuration field
+	ErrAuthFieldNotFound = New("malformed entity specification. authentication fields are expected on configuration field")
 
-	// ErrInvalidSchemeType indicates invalid scheme key on authentication field
-	ErrInvalidSchemeType = New("malformed entity specification. scheme key on authentication field is invalid")
+	// ErrAuthTypeNotFound indicates that authentication type field was not found on the authentication field
+	ErrAuthTypeNotFound = New("malformed entity specification: authentication type field is expected on configuration field")
 
-	// ErrInvalidTokenType indicates invalid token key on authentication field
-	ErrInvalidTokenType = New("malformed entity specification. token key on authentication field is invalid")
+	// ErrAuthInvalidType indicates invalid authentication type
+	ErrAuthInvalidType = New("malformed entity specification. type key on authentication field is invalid")
 
-	// ErrInvalidUsernameType indicates invalid username key on authentication field
-	ErrInvalidUsernameType = New("malformed entity specification. username key on authentication field is invalid")
+	// ErrAuthUsernameNotFound indicates that username key was not found
+	ErrAuthUsernameNotFound = New("malformed entity specification. username key is expected on authentication field")
+
+	// ErrAuthPasswordNotFound indicates that password key was not found
+	ErrAuthPasswordNotFound = New("malformed entity specification. password key is expected on authentication field")
+
+	// ErrAuthSchemeNotFound indicates that scheme key was not found
+	ErrAuthSchemeNotFound = New("malformed entity specification. scheme key is expected on authentication field")
+
+	// ErrAuthTokenNotFound indicates that token key was not found
+	ErrAuthTokenNotFound = New("malformed entity specification. token key is expected on authentication field")
+
+	// ErrAuthInvalidPasswordType indicates invalid password key on authentication field
+	ErrAuthInvalidPasswordType = New("malformed entity specification. password key on authentication field is invalid")
+
+	// ErrAuthInvalidSchemeType indicates invalid scheme key on authentication field
+	ErrAuthInvalidSchemeType = New("malformed entity specification. scheme key on authentication field is invalid")
+
+	// ErrAuthInvalidTokenType indicates invalid token key on authentication field
+	ErrAuthInvalidTokenType = New("malformed entity specification. token key on authentication field is invalid")
+
+	// ErrAuthInvalidUsernameType indicates invalid username key on authentication field
+	ErrAuthInvalidUsernameType = New("malformed entity specification. username key on authentication field is invalid")
 
 	// ErrRemoteHostNotFound indicates that remote host field was not found
 	ErrRemoteHostNotFound = New("malformed entity specification. remote host is expected on exporter field")

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -41,12 +41,18 @@ var (
 
 	// ErrAuthTypeNotFound indicates that authentication type field was not found on the authentication field
 	ErrAuthTypeNotFound = New("malformed entity specification: authentication type field is expected on configuration field")
-	
+
 	// ErrInvalidAuthType indicates invalid authentication type
 	ErrInvalidAuthType = New("malformed entity specification. type key on authentication field is invalid")
 
 	// ErrPasswordNotFound indicates that password key was not found
 	ErrPasswordNotFound = New("malformed entity specification. password key is expected on authentication field")
+
+	// ErrSchemeNotFound indicates that token key was not found
+	ErrSchemeNotFound = New("malformed entity specification. scheme key is expected on authentication field")
+
+	// ErrTokendNotFound indicates that token key was not found
+	ErrTokenNotFound = New("malformed entity specification. token key is expected on authentication field")
 
 	// ErrEndPointNotFound indicates that endpoint field was not found on exporter field for otlp backend
 	ErrEndpointNotFound = New("malformed entity specification. endpoint field is expected on exporter field")
@@ -56,6 +62,12 @@ var (
 
 	// ErrInvalidPasswordType indicates invalid password key on authentication field
 	ErrInvalidPasswordType = New("malformed entity specification. password key on authentication field is invalid")
+
+	// ErrInvalidSchemeType indicates invalid scheme key on authentication field
+	ErrInvalidSchemeType = New("malformed entity specification. scheme key on authentication field is invalid")
+
+	// ErrInvalidTokenType indicates invalid token key on authentication field
+	ErrInvalidTokenType = New("malformed entity specification. token key on authentication field is invalid")
 
 	// ErrInvalidUsernameType indicates invalid username key on authentication field
 	ErrInvalidUsernameType = New("malformed entity specification. username key on authentication field is invalid")

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -45,10 +45,13 @@ var (
 	// ErrInvalidAuthType indicates invalid authentication type
 	ErrInvalidAuthType = New("malformed entity specification. type key on authentication field is invalid")
 
+	// ErrUsernameNotFound indicates that username key was not found
+	ErrUsernameNotFound = New("malformed entity specification. username key is expected on authentication field")
+
 	// ErrPasswordNotFound indicates that password key was not found
 	ErrPasswordNotFound = New("malformed entity specification. password key is expected on authentication field")
 
-	// ErrSchemeNotFound indicates that token key was not found
+	// ErrSchemeNotFound indicates that scheme key was not found
 	ErrSchemeNotFound = New("malformed entity specification. scheme key is expected on authentication field")
 
 	// ErrTokendNotFound indicates that token key was not found

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -36,7 +36,7 @@ var (
 	// ErrExporterFieldNotFound indicates that exporter field was not found
 	ErrExporterFieldNotFound = New("malformed entity specification. exporter field is expected on configuration field")
 
-	// ErrEndPointNotFound indicates that endpoint field was not found on exporter field for otlp backend
+	// ErrEndpointNotFound indicates that endpoint field was not found on exporter field for otlp backend
 	ErrEndpointNotFound = New("malformed entity specification. endpoint field is expected on exporter field")
 
 	// ErrInvalidEndpoint indicates that endpoint field is not valid

--- a/sinks/api/http/endpoint_test.go
+++ b/sinks/api/http/endpoint_test.go
@@ -857,7 +857,7 @@ func TestAuthenticationTypesEndpoints(t *testing.T) {
 				err = json.Unmarshal(body, &authResponse)
 				require.NoError(t, err, "must not error")
 				require.NotNil(t, authResponse, "response must not be nil")
-				require.Equal(t, 1, len(authResponse.AuthenticationTypes), "must contain basicauth for now")
+				require.Equal(t, 2, len(authResponse.AuthenticationTypes), "must contain basicauth and bearertokenauth")
 			},
 		},
 		"view authentication type basicauth": {

--- a/sinks/api/http/requests.go
+++ b/sinks/api/http/requests.go
@@ -76,7 +76,7 @@ func GetConfigurationAndMetadataFromMeta(backendName string, config types.Metada
 	}
 	authTypeSvc, ok := authentication_type.GetAuthType(authtype.(string))
 	if !ok {
-		err = errors.Wrap(errors.ErrInvalidAuthType, errors.New("invalid required field authentication type"))
+		err = errors.Wrap(errors.ErrAuthInvalidType, errors.New("invalid required field authentication type"))
 		return
 	}
 	configSvc.Authentication = authTypeSvc
@@ -119,12 +119,12 @@ func GetConfigurationAndMetadataFromYaml(backendName string, config string) (con
 	case string:
 		break
 	default:
-		err = errors.ErrInvalidAuthType
+		err = errors.ErrAuthInvalidType
 		return
 	}
 	authTypeSvc, ok := authentication_type.GetAuthType(authtype.(string))
 	if !ok {
-		err = errors.Wrap(errors.ErrInvalidAuthType, errors.New("invalid required field authentication type"))
+		err = errors.Wrap(errors.ErrAuthInvalidType, errors.New("invalid required field authentication type"))
 		return
 	}
 	configSvc.Authentication = authTypeSvc

--- a/sinks/api/http/transport.go
+++ b/sinks/api/http/transport.go
@@ -242,25 +242,25 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, errors.ErrBackendNotFound):
 			w.WriteHeader(http.StatusBadRequest)
-		case errors.Contains(errorVal, errors.ErrUsernameNotFound):
+		case errors.Contains(errorVal, errors.ErrAuthUsernameNotFound):
 			w.WriteHeader(http.StatusBadRequest)
-		case errors.Contains(errorVal, errors.ErrPasswordNotFound):
+		case errors.Contains(errorVal, errors.ErrAuthPasswordNotFound):
 			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, errors.ErrAuthTypeNotFound):
 			w.WriteHeader(http.StatusBadRequest)
-		case errors.Contains(errorVal, errors.ErrInvalidUsernameType):
+		case errors.Contains(errorVal, errors.ErrAuthInvalidUsernameType):
 			w.WriteHeader(http.StatusBadRequest)
-		case errors.Contains(errorVal, errors.ErrInvalidPasswordType):
+		case errors.Contains(errorVal, errors.ErrAuthInvalidPasswordType):
 			w.WriteHeader(http.StatusBadRequest)
-		case errors.Contains(errorVal, errors.ErrInvalidTokenType):
+		case errors.Contains(errorVal, errors.ErrAuthInvalidTokenType):
 			w.WriteHeader(http.StatusBadRequest)
-		case errors.Contains(errorVal, errors.ErrTokenNotFound):
+		case errors.Contains(errorVal, errors.ErrAuthTokenNotFound):
 			w.WriteHeader(http.StatusBadRequest)
-		case errors.Contains(errorVal, errors.ErrInvalidSchemeType):
+		case errors.Contains(errorVal, errors.ErrAuthInvalidSchemeType):
 			w.WriteHeader(http.StatusBadRequest)
-		case errors.Contains(errorVal, errors.ErrSchemeNotFound):
+		case errors.Contains(errorVal, errors.ErrAuthSchemeNotFound):
 			w.WriteHeader(http.StatusBadRequest)
-		case errors.Contains(errorVal, errors.ErrInvalidAuthType):
+		case errors.Contains(errorVal, errors.ErrAuthInvalidType):
 			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, errors.ErrRemoteHostNotFound):
 			w.WriteHeader(http.StatusBadRequest)

--- a/sinks/api/http/transport.go
+++ b/sinks/api/http/transport.go
@@ -242,6 +242,8 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, errors.ErrBackendNotFound):
 			w.WriteHeader(http.StatusBadRequest)
+		case errors.Contains(errorVal, errors.ErrUsernameNotFound):
+			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, errors.ErrPasswordNotFound):
 			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, errors.ErrAuthTypeNotFound):

--- a/sinks/api/http/transport.go
+++ b/sinks/api/http/transport.go
@@ -236,7 +236,6 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		case errors.Contains(errorVal, errors.ErrUnsupportedContentType):
 			w.WriteHeader(http.StatusUnsupportedMediaType)
 
-			
 		case errors.Contains(errorVal, errors.ErrInvalidEndpoint):
 			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, errors.ErrEndpointNotFound):
@@ -251,8 +250,16 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, errors.ErrInvalidPasswordType):
 			w.WriteHeader(http.StatusBadRequest)
+		case errors.Contains(errorVal, errors.ErrInvalidTokenType):
+			w.WriteHeader(http.StatusBadRequest)
+		case errors.Contains(errorVal, errors.ErrTokenNotFound):
+			w.WriteHeader(http.StatusBadRequest)
+		case errors.Contains(errorVal, errors.ErrInvalidSchemeType):
+			w.WriteHeader(http.StatusBadRequest)
+		case errors.Contains(errorVal, errors.ErrSchemeNotFound):
+			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, errors.ErrInvalidAuthType):
-			w.WriteHeader(http.StatusBadRequest)	
+			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, errors.ErrRemoteHostNotFound):
 			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, errors.ErrAuthFieldNotFound):
@@ -262,7 +269,7 @@ func encodeError(_ context.Context, err error, w http.ResponseWriter) {
 		case errors.Contains(errorVal, errors.ErrExporterFieldNotFound):
 			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, errors.ErrInvalidBackend):
-			w.WriteHeader(http.StatusBadRequest)	
+			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, errors.ErrEntityNameNotFound):
 			w.WriteHeader(http.StatusBadRequest)
 		case errors.Contains(errorVal, errors.ErrMalformedEntity):

--- a/sinks/authentication_type/basicauth/authentication.go
+++ b/sinks/authentication_type/basicauth/authentication.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	AuthType              = "basicauth"
 	UsernameConfigFeature = "username"
 	PasswordConfigFeature = "password"
 )
@@ -35,11 +36,9 @@ var (
 	}
 )
 
-const AuthType = "basicauth"
-
 type AuthConfig struct {
-	Username          *string `json:"username" ,yaml:"username"`
-	Password          *string `json:"password" ,yaml:"password"`
+	Username          *string `json:"username" yaml:"username"`
+	Password          *string `json:"password" yaml:"password"`
 	encryptionService authentication_type.PasswordService
 }
 

--- a/sinks/authentication_type/basicauth/authentication.go
+++ b/sinks/authentication_type/basicauth/authentication.go
@@ -60,31 +60,31 @@ func (a *AuthConfig) ValidateConfiguration(inputFormat string, input interface{}
 	switch inputFormat {
 	case "object":
 		if _, ok := input.(types.Metadata)[UsernameConfigFeature]; !ok {
-			return errors.Wrap(errors.ErrUsernameNotFound, errors.New("username field was not found"))
+			return errors.Wrap(errors.ErrAuthUsernameNotFound, errors.New("username field was not found"))
 		}
 
 		if _, ok := input.(types.Metadata)[PasswordConfigFeature]; !ok {
-			return errors.Wrap(errors.ErrPasswordNotFound, errors.New("password field was not found"))
+			return errors.Wrap(errors.ErrAuthPasswordNotFound, errors.New("password field was not found"))
 		}
 
 		for key, value := range input.(types.Metadata) {
 			if key == UsernameConfigFeature {
 				if _, ok := value.(string); !ok {
-					return errors.Wrap(errors.ErrInvalidUsernameType, errors.New("invalid auth type for field: "+key))
+					return errors.Wrap(errors.ErrAuthInvalidUsernameType, errors.New("invalid auth type for field: "+key))
 				}
 
 				if len(strings.Fields(value.(string))) == 0 {
-					return errors.Wrap(errors.ErrInvalidUsernameType, errors.New("invalid authentication username"))
+					return errors.Wrap(errors.ErrAuthInvalidUsernameType, errors.New("invalid authentication username"))
 				}
 			}
 
 			if key == PasswordConfigFeature {
 				if _, ok := value.(string); !ok {
-					return errors.Wrap(errors.ErrInvalidPasswordType, errors.New("invalid auth type for field: "+key))
+					return errors.Wrap(errors.ErrAuthInvalidPasswordType, errors.New("invalid auth type for field: "+key))
 				}
 
 				if len(strings.Fields(value.(string))) == 0 {
-					return errors.Wrap(errors.ErrInvalidPasswordType, errors.New("invalid authentication password"))
+					return errors.Wrap(errors.ErrAuthInvalidPasswordType, errors.New("invalid authentication password"))
 				}
 			}
 		}
@@ -95,19 +95,19 @@ func (a *AuthConfig) ValidateConfiguration(inputFormat string, input interface{}
 		}
 
 		if a.Username == nil {
-			return errors.Wrap(errors.ErrUsernameNotFound, errors.New("username field was not found"))
+			return errors.Wrap(errors.ErrAuthUsernameNotFound, errors.New("username field was not found"))
 		}
 
 		if len(strings.Fields(*a.Username)) == 0 {
-			return errors.Wrap(errors.ErrInvalidUsernameType, errors.New("invalid authentication username"))
+			return errors.Wrap(errors.ErrAuthInvalidUsernameType, errors.New("invalid authentication username"))
 		}
 
 		if a.Password == nil {
-			return errors.Wrap(errors.ErrPasswordNotFound, errors.New("password field was not found"))
+			return errors.Wrap(errors.ErrAuthPasswordNotFound, errors.New("password field was not found"))
 		}
 
 		if len(strings.Fields(*a.Password)) == 0 {
-			return errors.Wrap(errors.ErrInvalidPasswordType, errors.New("invalid authentication password"))
+			return errors.Wrap(errors.ErrAuthInvalidPasswordType, errors.New("invalid authentication password"))
 		}
 	}
 
@@ -176,7 +176,7 @@ func (a *AuthConfig) EncodeInformation(outputFormat string, input interface{}) (
 		inputMeta := input.(types.Metadata)
 		authMeta := inputMeta.GetSubMetadata(authentication_type.AuthenticationKey)
 		if _, ok := authMeta[PasswordConfigFeature].(string); !ok {
-			return nil, errors.Wrap(errors.ErrPasswordNotFound, errors.New("password field was not found"))
+			return nil, errors.Wrap(errors.ErrAuthPasswordNotFound, errors.New("password field was not found"))
 		}
 		encoded, err := a.encryptionService.EncodePassword(authMeta[PasswordConfigFeature].(string))
 		if err != nil {

--- a/sinks/authentication_type/basicauth/authentication_test.go
+++ b/sinks/authentication_type/basicauth/authentication_test.go
@@ -27,7 +27,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"password": "test-password",
 				},
 			},
-			wantErr: errors.ErrUsernameNotFound,
+			wantErr: errors.ErrAuthUsernameNotFound,
 		},
 		{
 			name: "empty_username",
@@ -38,7 +38,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"password": "test-password",
 				},
 			},
-			wantErr: errors.ErrInvalidUsernameType,
+			wantErr: errors.ErrAuthInvalidUsernameType,
 		},
 		{
 			name: "invalid_username_type",
@@ -49,7 +49,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"password": "test-password",
 				},
 			},
-			wantErr: errors.ErrInvalidUsernameType,
+			wantErr: errors.ErrAuthInvalidUsernameType,
 		},
 		{
 			name: "invalid_username",
@@ -60,7 +60,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"password": "test-password",
 				},
 			},
-			wantErr: errors.ErrInvalidUsernameType,
+			wantErr: errors.ErrAuthInvalidUsernameType,
 		},
 		{
 			name: "missing_password",
@@ -70,7 +70,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"username": "test-user",
 				},
 			},
-			wantErr: errors.ErrPasswordNotFound,
+			wantErr: errors.ErrAuthPasswordNotFound,
 		},
 		{
 			name: "empty_password",
@@ -81,7 +81,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"password": "",
 				},
 			},
-			wantErr: errors.ErrInvalidPasswordType,
+			wantErr: errors.ErrAuthInvalidPasswordType,
 		},
 		{
 			name: "invalid_password_type",
@@ -92,7 +92,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"password": 1234,
 				},
 			},
-			wantErr: errors.ErrInvalidPasswordType,
+			wantErr: errors.ErrAuthInvalidPasswordType,
 		},
 		{
 			name: "invalid_password",
@@ -103,7 +103,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"password": " ",
 				},
 			},
-			wantErr: errors.ErrInvalidPasswordType,
+			wantErr: errors.ErrAuthInvalidPasswordType,
 		},
 		{
 			name: "valid",

--- a/sinks/authentication_type/basicauth/authentication_test.go
+++ b/sinks/authentication_type/basicauth/authentication_test.go
@@ -1,0 +1,132 @@
+package basicauth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/orb-community/orb/pkg/errors"
+	"github.com/orb-community/orb/pkg/types"
+)
+
+func TestAuthConfig_ValidateConfiguration(t *testing.T) {
+	type args struct {
+		inputFormat string
+		input       types.Metadata
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name: "missing_username",
+			args: args{
+				inputFormat: "object",
+				input: types.Metadata{
+					"password": "test-password",
+				},
+			},
+			wantErr: errors.ErrUsernameNotFound,
+		},
+		{
+			name: "empty_username",
+			args: args{
+				inputFormat: "object",
+				input: types.Metadata{
+					"username": "",
+					"password": "test-password",
+				},
+			},
+			wantErr: errors.ErrInvalidUsernameType,
+		},
+		{
+			name: "invalid_username_type",
+			args: args{
+				inputFormat: "object",
+				input: types.Metadata{
+					"username": 1234,
+					"password": "test-password",
+				},
+			},
+			wantErr: errors.ErrInvalidUsernameType,
+		},
+		{
+			name: "invalid_username",
+			args: args{
+				inputFormat: "object",
+				input: types.Metadata{
+					"username": " ",
+					"password": "test-password",
+				},
+			},
+			wantErr: errors.ErrInvalidUsernameType,
+		},
+		{
+			name: "missing_password",
+			args: args{
+				inputFormat: "object",
+				input: types.Metadata{
+					"username": "test-user",
+				},
+			},
+			wantErr: errors.ErrPasswordNotFound,
+		},
+		{
+			name: "empty_password",
+			args: args{
+				inputFormat: "object",
+				input: types.Metadata{
+					"username": "test-user",
+					"password": "",
+				},
+			},
+			wantErr: errors.ErrInvalidPasswordType,
+		},
+		{
+			name: "invalid_password_type",
+			args: args{
+				inputFormat: "object",
+				input: types.Metadata{
+					"username": "test-user",
+					"password": 1234,
+				},
+			},
+			wantErr: errors.ErrInvalidPasswordType,
+		},
+		{
+			name: "invalid_password",
+			args: args{
+				inputFormat: "object",
+				input: types.Metadata{
+					"username": "test-user",
+					"password": " ",
+				},
+			},
+			wantErr: errors.ErrInvalidPasswordType,
+		},
+		{
+			name: "valid",
+			args: args{
+				inputFormat: "object",
+				input: types.Metadata{
+					"username": "test-user",
+					"password": "test-password",
+				},
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var a AuthConfig
+			err := a.ValidateConfiguration(tt.args.inputFormat, tt.args.input)
+			if tt.wantErr != nil {
+				assert.ErrorContains(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/sinks/authentication_type/bearertokenauth/authentication.go
+++ b/sinks/authentication_type/bearertokenauth/authentication.go
@@ -51,30 +51,30 @@ func (a *AuthConfig) ValidateConfiguration(inputFormat string, input any) error 
 	switch inputFormat {
 	case "object":
 		if _, ok := input.(types.Metadata)[SchemeConfigFeature]; !ok {
-			return errors.Wrap(errors.ErrSchemeNotFound, errors.New("scheme field was not found"))
+			return errors.Wrap(errors.ErrAuthSchemeNotFound, errors.New("scheme field was not found"))
 		}
 
 		if _, ok := input.(types.Metadata)[TokenConfigFeature]; !ok {
-			return errors.Wrap(errors.ErrTokenNotFound, errors.New("token field was not found"))
+			return errors.Wrap(errors.ErrAuthTokenNotFound, errors.New("token field was not found"))
 		}
 
 		for key, value := range input.(types.Metadata) {
 			if key == SchemeConfigFeature {
 				if _, ok := value.(string); !ok {
-					return errors.Wrap(errors.ErrInvalidSchemeType, errors.New("invalid auth type for field: "+key))
+					return errors.Wrap(errors.ErrAuthInvalidSchemeType, errors.New("invalid auth type for field: "+key))
 				}
 
 				if len(strings.Fields(value.(string))) != 1 {
-					return errors.Wrap(errors.ErrInvalidSchemeType, errors.New("invalid authentication scheme"))
+					return errors.Wrap(errors.ErrAuthInvalidSchemeType, errors.New("invalid authentication scheme"))
 				}
 			}
 
 			if key == TokenConfigFeature {
 				if _, ok := value.(string); !ok {
-					return errors.Wrap(errors.ErrInvalidTokenType, errors.New("invalid auth type for field: "+key))
+					return errors.Wrap(errors.ErrAuthInvalidTokenType, errors.New("invalid auth type for field: "+key))
 				}
 				if len(strings.Fields(value.(string))) != 1 {
-					return errors.Wrap(errors.ErrInvalidTokenType, errors.New("invalid authentication token"))
+					return errors.Wrap(errors.ErrAuthInvalidTokenType, errors.New("invalid authentication token"))
 				}
 			}
 		}
@@ -85,19 +85,19 @@ func (a *AuthConfig) ValidateConfiguration(inputFormat string, input any) error 
 		}
 
 		if a.Scheme == nil {
-			return errors.Wrap(errors.ErrSchemeNotFound, errors.New("scheme field was not found"))
+			return errors.Wrap(errors.ErrAuthSchemeNotFound, errors.New("scheme field was not found"))
 		}
 
 		if len(strings.Fields(*a.Scheme)) != 1 {
-			return errors.Wrap(errors.ErrInvalidSchemeType, errors.New("invalid authentication scheme"))
+			return errors.Wrap(errors.ErrAuthInvalidSchemeType, errors.New("invalid authentication scheme"))
 		}
 
 		if a.Token == nil {
-			return errors.Wrap(errors.ErrTokenNotFound, errors.New("token field was not found"))
+			return errors.Wrap(errors.ErrAuthTokenNotFound, errors.New("token field was not found"))
 		}
 
 		if len(strings.Fields(*a.Token)) != 1 {
-			return errors.Wrap(errors.ErrInvalidTokenType, errors.New("invalid authentication token"))
+			return errors.Wrap(errors.ErrAuthInvalidTokenType, errors.New("invalid authentication token"))
 		}
 	}
 
@@ -173,7 +173,7 @@ func (a *AuthConfig) EncodeInformation(outputFormat string, input interface{}) (
 		authMeta := inputMeta.GetSubMetadata(authentication_type.AuthenticationKey)
 
 		if _, ok := authMeta[TokenConfigFeature].(string); !ok {
-			return nil, errors.Wrap(errors.ErrTokenNotFound, errors.New("token field was not found"))
+			return nil, errors.Wrap(errors.ErrAuthTokenNotFound, errors.New("token field was not found"))
 		}
 
 		encoded, err := a.encryptionService.EncodePassword(authMeta[TokenConfigFeature].(string))

--- a/sinks/authentication_type/bearertokenauth/authentication.go
+++ b/sinks/authentication_type/bearertokenauth/authentication.go
@@ -1,0 +1,280 @@
+package bearertokenauth
+
+import (
+	"gopkg.in/yaml.v2"
+
+	"github.com/orb-community/orb/pkg/errors"
+	"github.com/orb-community/orb/pkg/types"
+	"github.com/orb-community/orb/sinks/authentication_type"
+	"github.com/orb-community/orb/sinks/backend"
+)
+
+const (
+	AuthType            = "bearertokenauth"
+	SchemeConfigFeature = "scheme"
+	TokenConfigFeature  = "token"
+)
+
+var features = []authentication_type.ConfigFeature{
+	{
+		Type:     backend.ConfigFeatureTypeText,
+		Input:    "text",
+		Title:    "Scheme",
+		Name:     SchemeConfigFeature,
+		Required: true,
+	},
+	{
+		Type:     backend.ConfigFeatureTypeText,
+		Input:    "text",
+		Title:    "Token",
+		Name:     TokenConfigFeature,
+		Required: true,
+	},
+}
+
+type (
+	AuthConfig struct {
+		encryptionService authentication_type.PasswordService
+
+		Scheme string `json:"scheme" ,yaml:"scheme"`
+		Token  string `json:"token" ,yaml:"token"`
+	}
+)
+
+func (a *AuthConfig) GetFeatureConfig() []authentication_type.ConfigFeature {
+	return features
+}
+
+func (a *AuthConfig) ValidateConfiguration(inputFormat string, input any) error {
+	switch inputFormat {
+	case "object":
+		for key, value := range input.(types.Metadata) {
+			if _, ok := value.(string); !ok {
+				if key == "scheme" {
+					return errors.Wrap(errors.ErrInvalidSchemeType, errors.New("invalid auth type for field: "+key))
+				}
+
+				if key == "token" {
+					return errors.Wrap(errors.ErrInvalidTokenType, errors.New("invalid auth type for field: "+key))
+				}
+			}
+
+			vs := value.(string)
+
+			if key == SchemeConfigFeature {
+				if vs == "" {
+					return errors.New("scheme cannot be empty")
+				}
+			}
+
+			if key == TokenConfigFeature {
+				if vs == "" {
+					return errors.New("token cannot be empty")
+				}
+			}
+		}
+	case "yaml":
+		err := yaml.Unmarshal([]byte(input.(string)), &a)
+		if err != nil {
+			return err
+		}
+
+		if a.Scheme == "" {
+			return errors.New("scheme cannot be empty")
+		}
+
+		if a.Token == "" {
+			return errors.New("token cannot be empty")
+		}
+	}
+
+	return nil
+}
+
+func (a *AuthConfig) ConfigToFormat(outputFormat string, input any) (any, error) {
+	switch input.(type) {
+	case types.Metadata:
+		if outputFormat == "yaml" {
+			retVal, err := yaml.Marshal(input)
+
+			return string(retVal), err
+		}
+	case string:
+		if outputFormat == "object" {
+			retVal := make(types.Metadata)
+			val := input.(string)
+			err := yaml.Unmarshal([]byte(val), &retVal)
+
+			return retVal, err
+		}
+	}
+
+	return nil, errors.New("unsupported format")
+}
+
+func (a *AuthConfig) OmitInformation(outputFormat string, input any) (any, error) {
+	switch input.(type) {
+	case types.Metadata:
+		inputMeta := input.(types.Metadata)
+		authMeta := inputMeta.GetSubMetadata(authentication_type.AuthenticationKey)
+		authMeta[TokenConfigFeature] = ""
+		inputMeta[authentication_type.AuthenticationKey] = authMeta
+
+		if outputFormat == "yaml" {
+			return a.ConfigToFormat("yaml", inputMeta)
+		}
+
+		if outputFormat == "object" {
+			return inputMeta, nil
+		}
+
+		return nil, errors.New("unsupported format")
+	case string:
+		iia, err := a.ConfigToFormat("object", input)
+		if err != nil {
+			return nil, err
+		}
+		inputMeta := iia.(types.Metadata)
+		authMeta := inputMeta.GetSubMetadata(authentication_type.AuthenticationKey)
+		authMeta[TokenConfigFeature] = ""
+		inputMeta[authentication_type.AuthenticationKey] = authMeta
+
+		if outputFormat == "yaml" {
+			return a.ConfigToFormat("yaml", inputMeta)
+		}
+
+		if outputFormat == "object" {
+			return inputMeta, nil
+		}
+
+		return nil, errors.New("unsupported format")
+	}
+
+	return nil, errors.New("unsupported format")
+}
+
+func (a *AuthConfig) EncodeInformation(outputFormat string, input interface{}) (interface{}, error) {
+	switch input.(type) {
+	case types.Metadata:
+		inputMeta := input.(types.Metadata)
+		authMeta := inputMeta.GetSubMetadata(authentication_type.AuthenticationKey)
+
+		if _, ok := authMeta[TokenConfigFeature].(string); !ok {
+			return nil, errors.Wrap(errors.ErrTokenNotFound, errors.New("token field was not found"))
+		}
+
+		encoded, err := a.encryptionService.EncodePassword(authMeta[TokenConfigFeature].(string))
+		if err != nil {
+			return nil, err
+		}
+
+		authMeta[TokenConfigFeature] = encoded
+		inputMeta[authentication_type.AuthenticationKey] = authMeta
+
+		if outputFormat == "yaml" {
+			return a.ConfigToFormat("yaml", inputMeta)
+		}
+
+		if outputFormat == "object" {
+			return inputMeta, nil
+		}
+
+		return nil, errors.New("unsupported format")
+	case string:
+		iia, err := a.ConfigToFormat("object", input)
+		if err != nil {
+			return nil, err
+		}
+		inputMeta := iia.(types.Metadata)
+		authMeta := inputMeta.GetSubMetadata(authentication_type.AuthenticationKey)
+
+		encoded, err := a.encryptionService.EncodePassword(authMeta[TokenConfigFeature].(string))
+		if err != nil {
+			return nil, err
+		}
+
+		authMeta[TokenConfigFeature] = encoded
+		inputMeta[authentication_type.AuthenticationKey] = authMeta
+
+		if outputFormat == "yaml" {
+			return a.ConfigToFormat("yaml", inputMeta)
+		}
+
+		if outputFormat == "object" {
+			return inputMeta, nil
+		}
+
+		return nil, errors.New("unsupported format")
+	}
+
+	return nil, errors.New("unsupported format")
+}
+
+func (a *AuthConfig) DecodeInformation(outputFormat string, input any) (any, error) {
+	switch input.(type) {
+	case types.Metadata:
+		inputMeta := input.(types.Metadata)
+		authMeta := inputMeta.GetSubMetadata(authentication_type.AuthenticationKey)
+
+		decoded, err := a.encryptionService.DecodePassword(authMeta[TokenConfigFeature].(string))
+		if err != nil {
+			return nil, err
+		}
+
+		authMeta[TokenConfigFeature] = decoded
+		inputMeta[authentication_type.AuthenticationKey] = authMeta
+
+		if outputFormat == "yaml" {
+			return a.ConfigToFormat("yaml", inputMeta)
+		}
+
+		if outputFormat == "object" {
+			return inputMeta, nil
+		}
+
+		return nil, errors.New("unsupported format")
+	case string:
+		iia, err := a.ConfigToFormat("object", input)
+		if err != nil {
+			return nil, err
+		}
+
+		inputMeta := iia.(types.Metadata)
+		authMeta := inputMeta.GetSubMetadata(authentication_type.AuthenticationKey)
+
+		decoded, err := a.encryptionService.DecodePassword(authMeta[TokenConfigFeature].(string))
+		if err != nil {
+			return nil, err
+		}
+
+		authMeta[TokenConfigFeature] = decoded
+		inputMeta[authentication_type.AuthenticationKey] = authMeta
+
+		if outputFormat == "yaml" {
+			return a.ConfigToFormat("yaml", inputMeta)
+		}
+
+		if outputFormat == "object" {
+			return inputMeta, nil
+		}
+
+		return nil, errors.New("unsupported format")
+	}
+
+	return nil, errors.New("unsupported format")
+}
+
+func (a *AuthConfig) Metadata() authentication_type.AuthenticationTypeConfig {
+	return authentication_type.AuthenticationTypeConfig{
+		Type:        AuthType,
+		Description: "Token authentication",
+		Config:      features,
+	}
+}
+
+func Register(encryptionService authentication_type.PasswordService) {
+	bearerTokenAuth := AuthConfig{
+		encryptionService: encryptionService,
+	}
+	authentication_type.Register(AuthType, &bearerTokenAuth)
+}

--- a/sinks/authentication_type/bearertokenauth/authentication.go
+++ b/sinks/authentication_type/bearertokenauth/authentication.go
@@ -34,14 +34,12 @@ var features = []authentication_type.ConfigFeature{
 	},
 }
 
-type (
-	AuthConfig struct {
-		encryptionService authentication_type.PasswordService
+type AuthConfig struct {
+	encryptionService authentication_type.PasswordService
 
-		Scheme *string `json:"scheme" ,yaml:"scheme"`
-		Token  *string `json:"token" ,yaml:"token"`
-	}
-)
+	Scheme *string `json:"scheme" yaml:"scheme"`
+	Token  *string `json:"token" yaml:"token"`
+}
 
 func (a *AuthConfig) GetFeatureConfig() []authentication_type.ConfigFeature {
 	return features

--- a/sinks/authentication_type/bearertokenauth/authentication_test.go
+++ b/sinks/authentication_type/bearertokenauth/authentication_test.go
@@ -29,7 +29,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"token": "test_api_key",
 				},
 			},
-			wantErr: errors.ErrSchemeNotFound,
+			wantErr: errors.ErrAuthSchemeNotFound,
 		},
 		{
 			name: "empty_schema",
@@ -40,7 +40,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"token":  "test_api_key",
 				},
 			},
-			wantErr: errors.ErrInvalidSchemeType,
+			wantErr: errors.ErrAuthInvalidSchemeType,
 		},
 		{
 			name: "invalid_schema_type",
@@ -51,7 +51,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"token":  "test_api_key",
 				},
 			},
-			wantErr: errors.ErrInvalidSchemeType,
+			wantErr: errors.ErrAuthInvalidSchemeType,
 		},
 		{
 			name: "invalid_schema",
@@ -62,7 +62,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"token":  "test_api_key",
 				},
 			},
-			wantErr: errors.ErrInvalidSchemeType,
+			wantErr: errors.ErrAuthInvalidSchemeType,
 		},
 		{
 			name: "missing_token",
@@ -72,7 +72,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"scheme": "Bearer",
 				},
 			},
-			wantErr: errors.ErrTokenNotFound,
+			wantErr: errors.ErrAuthTokenNotFound,
 		},
 		{
 			name: "empty_token",
@@ -83,7 +83,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"token":  "",
 				},
 			},
-			wantErr: errors.ErrInvalidTokenType,
+			wantErr: errors.ErrAuthInvalidTokenType,
 		},
 		{
 			name: "invalid_token_type",
@@ -94,7 +94,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"token":  1234,
 				},
 			},
-			wantErr: errors.ErrInvalidTokenType,
+			wantErr: errors.ErrAuthInvalidTokenType,
 		},
 		{
 			name: "invalid_token_value",
@@ -105,7 +105,7 @@ func TestAuthConfig_ValidateConfiguration(t *testing.T) {
 					"token":  "invalid api key",
 				},
 			},
-			wantErr: errors.ErrInvalidTokenType,
+			wantErr: errors.ErrAuthInvalidTokenType,
 		},
 		{
 			name: "valid",

--- a/sinks/authentication_type/bearertokenauth/authentication_test.go
+++ b/sinks/authentication_type/bearertokenauth/authentication_test.go
@@ -1,0 +1,181 @@
+package bearertokenauth
+
+import (
+	"testing"
+
+	"github.com/orb-community/orb/pkg/types"
+	"github.com/orb-community/orb/sinks/authentication_type"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthConfig_ValidateConfiguration(t *testing.T) {
+	type args struct {
+		inputFormat string
+		input       types.Metadata
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "missing_schema",
+			args: args{
+				inputFormat: "object",
+				input: types.Metadata{
+					"scheme": "",
+					"token":  "test_api_key",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing_token",
+			args: args{
+				inputFormat: "object",
+				input: types.Metadata{
+					"scheme": "Bearer",
+					"token":  "",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid",
+			args: args{
+				inputFormat: "object",
+				input: types.Metadata{
+					"scheme": "Bearer",
+					"token":  "abcdefg",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var a AuthConfig
+			err := a.ValidateConfiguration(tt.args.inputFormat, tt.args.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAuthConfig_OmitInformation(t *testing.T) {
+	t.Run("invalid output format", func(t *testing.T) {
+		input := types.Metadata{
+			"authentication": types.Metadata{
+				"scheme": "Bearer",
+				"token":  "abcdefg",
+			},
+		}
+
+		var a AuthConfig
+
+		_, err := a.OmitInformation("blah", input)
+		assert.Error(t, err)
+	})
+	t.Run("successfully stripped the secret token", func(t *testing.T) {
+		input := types.Metadata{
+			"authentication": types.Metadata{
+				"scheme": "Bearer",
+				"token":  "abcdefg",
+			},
+		}
+
+		want := types.Metadata{
+			"authentication": types.Metadata{
+				"scheme": "Bearer",
+				"token":  "",
+			},
+		}
+
+		var a AuthConfig
+
+		got, err := a.OmitInformation("object", input)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+}
+
+func TestAuthConfig_EncodeInformation(t *testing.T) {
+	t.Run("invalid output format", func(t *testing.T) {
+		input := types.Metadata{
+			"authentication": types.Metadata{
+				"scheme": "Bearer",
+				"token":  "abcdefg",
+			},
+		}
+
+		a := AuthConfig{
+			encryptionService: authentication_type.NewPasswordService(nil, "test"),
+		}
+
+		_, err := a.EncodeInformation("blah", input)
+		assert.Error(t, err)
+	})
+
+	t.Run("successfully encrypted token", func(t *testing.T) {
+		input := types.Metadata{
+			"authentication": types.Metadata{
+				"scheme": "Bearer",
+				"token":  "abcdefg",
+			},
+		}
+
+		a := AuthConfig{
+			encryptionService: authentication_type.NewPasswordService(nil, "test"),
+		}
+
+		_, err := a.EncodeInformation("object", input)
+		require.NoError(t, err)
+	})
+}
+
+func TestAuthConfig_DecodeInformation(t *testing.T) {
+	t.Run("invalid output format", func(t *testing.T) {
+		input := types.Metadata{
+			"authentication": types.Metadata{
+				"scheme": "Bearer",
+				"token":  "dca8757dee5dfcc592c97355396dc2bdb95c6a3f58d4acb4453717c960827602acaf49",
+			},
+		}
+
+		a := AuthConfig{
+			encryptionService: authentication_type.NewPasswordService(nil, "test"),
+		}
+
+		_, err := a.DecodeInformation("blah", input)
+		assert.Error(t, err)
+	})
+
+	t.Run("successfully decrypted token", func(t *testing.T) {
+		input := types.Metadata{
+			"authentication": types.Metadata{
+				"scheme": "Bearer",
+				"token":  "dca8757dee5dfcc592c97355396dc2bdb95c6a3f58d4acb4453717c960827602acaf49",
+			},
+		}
+
+		want := types.Metadata{
+			"authentication": types.Metadata{
+				"scheme": "Bearer",
+				"token":  "abcdefg",
+			},
+		}
+
+		a := AuthConfig{
+			encryptionService: authentication_type.NewPasswordService(nil, "test"),
+		}
+
+		got, err := a.DecodeInformation("object", input)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+}

--- a/sinks/service.go
+++ b/sinks/service.go
@@ -10,16 +10,19 @@ package sinks
 
 import (
 	"context"
+	"time"
+
 	"github.com/mainflux/mainflux"
 	mfsdk "github.com/mainflux/mainflux/pkg/sdk/go"
+	"go.uber.org/zap"
+
 	"github.com/orb-community/orb/pkg/errors"
 	"github.com/orb-community/orb/pkg/types"
 	"github.com/orb-community/orb/sinks/authentication_type"
 	"github.com/orb-community/orb/sinks/authentication_type/basicauth"
+	"github.com/orb-community/orb/sinks/authentication_type/bearertokenauth"
 	"github.com/orb-community/orb/sinks/backend/otlphttpexporter"
 	"github.com/orb-community/orb/sinks/backend/prometheus"
-	"go.uber.org/zap"
-	"time"
 )
 
 // PageMetadata contains page metadata that helps navigation
@@ -67,7 +70,7 @@ func NewSinkService(logger *zap.Logger, auth mainflux.AuthServiceClient, sinkRep
 	otlphttpexporter.Register()
 	prometheus.Register()
 	basicauth.Register(passwordService)
-	// bearerauth.Register(passwordService)
+	bearertokenauth.Register(passwordService)
 	return &sinkService{
 		logger:          logger,
 		auth:            auth,

--- a/sinks/sinks_service.go
+++ b/sinks/sinks_service.go
@@ -96,12 +96,12 @@ func validateAuthType(s *Sink) (authentication_type.AuthenticationType, error) {
 	}
 
 	if _, ok := authTypeStr.(string); !ok {
-		return nil, errors.Wrap(errors.ErrInvalidAuthType, errors.New("invalid authentication type"))
+		return nil, errors.Wrap(errors.ErrAuthInvalidType, errors.New("invalid authentication type"))
 	}
 
 	authType, ok := authentication_type.GetAuthType(authTypeStr.(string))
 	if !ok {
-		return nil, errors.Wrap(errors.ErrInvalidAuthType, errors.New("invalid authentication type"))
+		return nil, errors.Wrap(errors.ErrAuthInvalidType, errors.New("invalid authentication type"))
 	}
 
 	err := authType.ValidateConfiguration("object", authMetadata)

--- a/ui/src/app/pages/sinks/add/sink-add.component.ts
+++ b/ui/src/app/pages/sinks/add/sink-add.component.ts
@@ -79,14 +79,7 @@ export class SinkAddComponent {
 
         return !this.editor.checkEmpty(config.authentication)
         && !this.editor.checkEmpty(config.exporter)
-        && detailsValid
-        && !this.checkString(config);
-    }
-    checkString(config: any): boolean {
-        if (typeof config.authentication.password !== 'string' || typeof config.authentication.username !== 'string') {
-            return true;
-        }
-        return false;
+        && detailsValid;
     }
 
     createSink() {


### PR DESCRIPTION
Enable sinks to be configured with token based authentication.
The required fields for this auth type are:

1. `scheme`
2. `token`

Rather than `scheme` being fixed to `Bearer`, it's customizable because there are [many schemes it could be](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml).
For example Dynatrace expect the header to be:
`Authorization: Api-Token dt0c01.abc123.abcdefjhij1234567890`

With the following authentication settings configured on a sink:

```json
{
	"exporter": {
		"endpoint": "https://acme.com/otlphttp/push"
	},
	"authentication": {
		"type": "bearertokenauth",
		"scheme": "Api-Token",
		"token": "abcdefg"
	}
}
```

The resulting yaml configuration is:
```yaml
---
receivers:
  kafka:
    brokers:
    - kafka:9092
    topic: otlp_metrics-sink-id-22
    protocol_version: 2.0.0
extensions:
  pprof:
    endpoint: 0.0.0.0:1888
  bearertokenauth/withscheme:
    scheme: Api-Token
    token: abcdefg
exporters:
  otlphttp:
    endpoint: https://acme.com/otlphttp/push
    auth:
      authenticator: bearertokenauth/withscheme
service:
  extensions:
  - pprof
  - bearertokenauth/withscheme
  pipelines:
    metrics:
      receivers:
      - kafka
      exporters:
      - otlphttp
```

This is in line with what's expected:
https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/4115aad52e0775caed38c3ccc450d8064044efaa/extension/bearertokenauthextension